### PR TITLE
Add FFI wrappers to support curl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,5 +26,6 @@ _build/
 *~
 
 src/tls/libmitls.dll
+libs/ml/FFI.cmi
 libs/ml/FFI.cmx
 libs/ml/FFI.o

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,7 @@ _build/
 
 *.swp
 *~
+
+src/tls/libmitls.dll
+libs/ml/FFI.cmx
+libs/ml/FFI.o

--- a/libs/ml/FFI.ml
+++ b/libs/ml/FFI.ml
@@ -1,0 +1,15 @@
+let _ = Callback.register "MITLS_FFI_Config" TestClient13.ffiConfig;
+        Callback.register "MITLS_FFI_PrepareClientHello" TestClient13.ffiPrepareClientHello;
+        Callback.register "MITLS_FFI_HandleServerHello" TestClient13.ffiHandleServerHello;
+        Callback.register "MITLS_FFI_HandleEncryptedExtensions" TestClient13.ffiHandleEncryptedExtensions;
+        Callback.register "MITLS_FFI_HandleCertificateVerify12" TestClient13.ffiHandleCertificateVerify12;
+        Callback.register "MITLS_FFI_HandleCertificateVerify13" TestClient13.ffiHandleCertificateVerify13;
+        Callback.register "MITLS_FFI_HandleServerKeyExchange" TestClient13.ffiHandleServerKeyExchange;
+        Callback.register "MITLS_FFI_HandleServerHelloDone" TestClient13.ffiHandleServerHelloDone;
+        Callback.register "MITLS_FFI_PrepareClientKeyExchange" TestClient13.ffiPrepareClientKeyExchange;
+        Callback.register "MITLS_FFI_PrepareChangeCipherSpec" TestClient13.ffiPrepareChangeCipherSpec;
+        Callback.register "MITLS_FFI_PrepareHandshake" TestClient13.ffiPrepareHandshake;
+        Callback.register "MITLS_FFI_HandleChangeCipherSpec" TestClient13.ffiHandleChangeCipherSpec;
+        Callback.register "MITLS_FFI_HandleServerFinished" TestClient13.ffiHandleServerFinished;
+        Callback.register "MITLS_FFI_PrepareSend" TestClient13.ffiPrepareSend;
+        Callback.register "MITLS_FFI_HandleReceive" TestClient13.ffiHandleReceive;

--- a/src/tls/Handshake.fst
+++ b/src/tls/Handshake.fst
@@ -1636,3 +1636,5 @@ val authorize: s:hs -> Cert.chain -> ST incoming // special case: explicit autho
   (ensures (fun h0 result h1 ->
     (is_InAck result \/ is_InError result) /\ recv_ensures s h0 result h1 ))
 let authorize s ch = Platform.Error.unexpected "authorize: not yet implemented"
+
+

--- a/src/tls/Makefile
+++ b/src/tls/Makefile
@@ -267,6 +267,7 @@ TLSML := \
   $(TLSML)
 # Last step: prefix with the output directory.
 TLSML := $(addprefix $(OUTPUT_DIR)/,$(notdir $(TLSML)))
+TLSML := $(TLSML) ../../libs/ml/FFI.ml
 
 refresh:
 	$(FSTAR_HOME)/src/tools/rebuild_fstar_if $(FSTAR_HOME)
@@ -329,3 +330,10 @@ test13:
 ifeq ($(OS),Windows_NT)
     EXTRA_PATH = PATH="/usr/x86_64-w64-mingw32/sys-root/mingw/bin/:$(PATH)"
 endif
+
+# FFI support - calling from C into miTLS
+#depends on tls-gen
+tls-ffi: libmitls.dll
+
+libmitls.dll: ffi.c mitls.cmxa #tls-gen
+	$(OCAML) $(OCAMLOPTS) $(OCAML_INCLUDE_PATHS) $(LIB_ML) -inline 0 ffi.c -linkall -g -output-obj mitls.cmxa -o libmitls.dll

--- a/src/tls/ffi.c
+++ b/src/tls/ffi.c
@@ -1,0 +1,304 @@
+#include <stdio.h>
+#include <memory.h>
+#include <caml/callback.h>
+#include <caml/alloc.h>
+#include <caml/memory.h>
+#include <caml/printexc.h>
+#include "mitlsffi.h"
+
+#define MITLS_FFI_LIST \
+  MITLS_FFI_ENTRY(Config) \
+  MITLS_FFI_ENTRY(PrepareClientHello) \
+  MITLS_FFI_ENTRY(HandleServerHello) \
+  MITLS_FFI_ENTRY(HandleEncryptedExtensions) \
+  MITLS_FFI_ENTRY(HandleCertificateVerify12) \
+  MITLS_FFI_ENTRY(HandleCertificateVerify13) \
+  MITLS_FFI_ENTRY(HandleServerKeyExchange) \
+  MITLS_FFI_ENTRY(HandleServerHelloDone) \
+  MITLS_FFI_ENTRY(PrepareClientKeyExchange) \
+  MITLS_FFI_ENTRY(PrepareChangeCipherSpec) \
+  MITLS_FFI_ENTRY(PrepareHandshake) \
+  MITLS_FFI_ENTRY(HandleChangeCipherSpec) \
+  MITLS_FFI_ENTRY(HandleServerFinished) \
+  MITLS_FFI_ENTRY(PrepareSend) \
+  MITLS_FFI_ENTRY(HandleReceive) \
+
+ 
+// Pointers to ML code.  Initialized in FFI_mitls_init().  Invoke via caml_callback()
+#define MITLS_FFI_ENTRY(x) value* g_mitls_FFI_##x;
+MITLS_FFI_LIST
+#undef MITLS_FFI_ENTRY
+
+int FFI_mitls_handle_simple(value* f, /* in out */ size_t *state, char* header, size_t header_size, char *record, size_t record_size);
+
+
+//
+// Initialize miTLS.
+//
+//  Called once ahead of using miTLS
+//
+//  Returns:  0 for error, nonzero for success
+//
+int  FFI_mitls_init(void)
+{
+    char*Argv[2];
+    value str;
+    value ret;
+    
+    // Build a stub argv[] to satisfy caml_Startup()
+    Argv[0] = "";
+    Argv[1] = NULL;
+    
+    // Initialize the OCaml runtime
+    caml_startup(Argv);
+    
+    // Bind to functions registered via Callback.register from ML
+#define MITLS_FFI_ENTRY(x) \
+    g_mitls_FFI_##x = caml_named_value("MITLS_FFI_" # x); \
+    if (!g_mitls_FFI_##x) { \
+        printf("Failed to bind to Caml callback MITLS_FFI_" # x "\n"); \
+        return 0; \
+    }
+ MITLS_FFI_LIST  
+ #undef MITLS_FFI_ENTRY
+    
+    return 1; // success
+}
+
+void FFI_mitls_cleanup(void)
+{
+#define MITLS_FFI_ENTRY(x) \
+    g_mitls_FFI_##x = NULL;
+ MITLS_FFI_LIST  
+ #undef MITLS_FFI_ENTRY
+}
+
+#define C_ASSERT(e) typedef char __C_ASSERT__[(e)?1:-1]
+C_ASSERT(sizeof(size_t) == sizeof(value));
+
+void FFI_mitls_config(size_t *configptr, const char *tls_version, const char *host_name)
+{
+    CAMLlocal3(config, version, host);
+
+    version = caml_copy_string(tls_version);  
+    host = caml_copy_string(host_name);
+    config = caml_callback2_exn(*g_mitls_FFI_Config, version, host);
+    if (Is_exception_result(config)) {
+        printf("Exception!  %s\n", caml_format_exception(Extract_exception(config)));
+        *configptr = 0;
+    } else {
+        // Tell the OCaml GC about the caller's variable address, so it is treated
+        // as a GC root, keeping the config object live.
+        caml_register_generational_global_root((value*)configptr);
+        *configptr = config;
+    }
+}
+
+void FFI_mitls_release_value(size_t *v)
+{
+    if (*v) {
+        // Remove the root from the OCaml GC tracker, so the object can be collected.
+        caml_remove_generational_global_root((value*)v);
+        *v = 0;
+    }
+}
+
+void * copypacket(value packet, /* out */ size_t *packet_size)
+{
+    void *p;
+    mlsize_t size;
+        
+    size = caml_string_length(packet);
+    p = malloc(size);
+    if (p) {
+        memcpy(p, String_val(packet), size);
+        *packet_size = size;
+    }
+    return p;
+}
+
+void FFI_mitls_free_packet(void *packet)
+{
+    free(packet);
+}
+
+void * FFI_mitls_prepare_simple(value *f, /* in out */ size_t *state, /* out */ size_t *packet_size)
+{
+    value state_value = (value)*state;
+    void *p = NULL;
+    CAMLparam1(state_value);
+    CAMLlocal1(ret);
+  
+    ret = caml_callback_exn(*f, state_value);
+    if (Is_exception_result(ret)) {
+        printf("Exception!  %s\n", caml_format_exception(Extract_exception(ret)));
+        p = NULL;
+    } else {
+        // The return value is a tuple containing the packet and the new config object
+        *state = Field(ret, 1);
+        p = copypacket(Field(ret, 0), packet_size);
+    }
+    
+    CAMLreturnT(void*,p);
+}
+
+void * FFI_mitls_prepare_client_hello(/* in out */ size_t *state, /* out */ size_t *packet_size)
+{
+    void *p;
+    p = FFI_mitls_prepare_simple(g_mitls_FFI_PrepareClientHello, state, packet_size);
+    return p;
+}
+
+int FFI_mitls_handle_simple(value* f, /* in out */ size_t *state, char* header, size_t header_size, char *record, size_t record_size)
+{
+    value state_value = (value)*state;
+    int ret = 0;
+    CAMLparam1(state_value);
+    CAMLlocal3(header_value, record_value, result);
+
+    header_value = caml_alloc_string(header_size);
+    memcpy(Bp_val(header_value), header, header_size);
+    
+    record_value = caml_alloc_string(record_size);
+    memcpy(Bp_val(record_value), record, record_size);
+    
+    result = caml_callback3_exn(*f, state_value, header_value, record_value);
+    if (Is_exception_result(result)) {
+        printf("Exception!  %s\n", caml_format_exception(Extract_exception(result)));
+        ret = 0;
+    } else {
+        // The return is a just the updated state
+        *state = result;
+        ret = 1;
+    }
+    
+    CAMLreturnT(int, ret);
+}
+
+
+int FFI_mitls_handle_server_hello(/* in out */ size_t *state, char* header, size_t header_size, char *record, size_t record_size)
+{
+    int ret;
+    ret = FFI_mitls_handle_simple(g_mitls_FFI_HandleServerHello, state, header, header_size, record, record_size);
+    return ret;
+}
+
+int FFI_mitls_handle_encrypted_extensions(/* in out */ size_t *state, char* header, size_t header_size, char *record, size_t record_size)
+{
+    int ret;
+    ret = FFI_mitls_handle_simple(g_mitls_FFI_HandleEncryptedExtensions, state, header, header_size, record, record_size);
+    return ret;
+}
+
+int FFI_mitls_handle_certificate_verify12(/* in out */ size_t *state, char* header, size_t header_size, char *record, size_t record_size)
+{
+    int ret;
+    ret = FFI_mitls_handle_simple(g_mitls_FFI_HandleCertificateVerify12, state, header, header_size, record, record_size);
+    return ret;
+}
+
+int FFI_mitls_handle_certificate_verify13(/* in out */ size_t *state, char* header, size_t header_size, char *record, size_t record_size)
+{
+    int ret;
+    ret = FFI_mitls_handle_simple(g_mitls_FFI_HandleCertificateVerify13, state, header, header_size, record, record_size);
+    return ret;
+}
+
+int FFI_mitls_handle_server_key_exchange(/* in out */ size_t *state, char* header, size_t header_size, char *record, size_t record_size)
+{
+    int ret;
+    ret = FFI_mitls_handle_simple(g_mitls_FFI_HandleServerKeyExchange, state, header, header_size, record, record_size);
+    return ret;
+}
+
+int FFI_mitls_handle_server_hello_done(/* in out */ size_t *state, char* header, size_t header_size, char *record, size_t record_size)
+{
+    int ret;
+    ret = FFI_mitls_handle_simple(g_mitls_FFI_HandleServerHelloDone, state, header, header_size, record, record_size);
+    return ret;
+}
+
+void * FFI_mitls_prepare_client_key_exchange(/* in out */ size_t *state, /* out */ size_t *packet_size)
+{
+    void *p;
+    p = FFI_mitls_prepare_simple(g_mitls_FFI_PrepareClientKeyExchange, state, packet_size);
+    return p;
+}
+
+void * FFI_mitls_prepare_change_cipher_spec(/* in out */ size_t *state, /* out */ size_t *packet_size)
+{
+    void *p;
+    p = FFI_mitls_prepare_simple(g_mitls_FFI_PrepareChangeCipherSpec, state, packet_size);
+    return p;
+}
+
+void * FFI_mitls_prepare_handshake(/* in out */ size_t *state, /* out */ size_t *packet_size)
+{
+    void *p;
+    p = FFI_mitls_prepare_simple(g_mitls_FFI_PrepareHandshake, state, packet_size);
+    return p;
+}
+
+int FFI_mitls_handle_change_cipher_spec(/* in out */ size_t *state, char* header, size_t header_size, char *record, size_t record_size)
+{
+    int ret;
+    ret = FFI_mitls_handle_simple(g_mitls_FFI_HandleChangeCipherSpec, state, header, header_size, record, record_size);
+    return ret;
+}
+
+int FFI_mitls_handle_server_finished(/* in out */ size_t *state, char* header, size_t header_size, char *record, size_t record_size)
+{
+    int ret;
+    ret = FFI_mitls_handle_simple(g_mitls_FFI_HandleServerFinished, state, header, header_size, record, record_size);
+    return ret;
+}
+
+
+void * FFI_mitls_prepare_send(/* in out */ size_t *state, const void* buffer, size_t buffer_size, /* out */ size_t *packet_size)
+{
+    value state_value = (value)*state;
+    void *p = NULL;
+    CAMLparam1(state_value);
+    CAMLlocal2(buffer_value, result);
+    
+    buffer_value = caml_alloc_string(buffer_size);
+    memcpy(Bp_val(buffer_value), buffer, buffer_size);
+    
+    result = caml_callback2_exn(*g_mitls_FFI_PrepareSend, state_value, buffer_value);
+    if (Is_exception_result(result)) {
+        printf("Exception!  %s\n", caml_format_exception(Extract_exception(result)));
+        p = NULL;
+    } else {
+        // The return the plaintext data
+        p = copypacket(result, packet_size);
+    }
+    
+    CAMLreturnT(void*, p);
+    
+}
+
+void * FFI_mitls_handle_receive(/* in out */ size_t *state, char* header, size_t header_size, char *record, size_t record_size, /* out */ size_t *packet_size)
+{
+    value state_value = (value)*state;
+    void *p = NULL;
+    CAMLparam1(state_value);
+    CAMLlocal3(header_value, record_value, result);
+
+    header_value = caml_alloc_string(header_size);
+    memcpy(Bp_val(header_value), header, header_size);
+    
+    record_value = caml_alloc_string(record_size);
+    memcpy(Bp_val(record_value), record, record_size);
+    
+    result = caml_callback3_exn(*g_mitls_FFI_HandleReceive, state_value, header_value, record_value);
+    if (Is_exception_result(result)) {
+        printf("Exception!  %s\n", caml_format_exception(Extract_exception(result)));
+        p = NULL;
+    } else {
+        // Return the plaintext data
+        p = copypacket(result, packet_size);
+    }
+    
+    CAMLreturnT(void*, p);
+}
+

--- a/src/tls/mitlsffi.h
+++ b/src/tls/mitlsffi.h
@@ -1,0 +1,27 @@
+#ifndef HEADER_MITLS_FFI_H
+#define HEADER_MITLS_FFI_H
+
+// Functions exported from libmitls.dll
+//   Functions returning 'int' return 0 for failure, or nonzero for success
+extern int  FFI_mitls_init(void);
+extern void FFI_mitls_cleanup(void);
+extern void FFI_mitls_config(size_t *stateptr, const char *tls_version, const char *host_name);
+extern void FFI_mitls_release_value(size_t *value);
+extern void FFI_mitls_free_packet(void *packet);
+extern void * FFI_mitls_prepare_client_hello(/* in out */ size_t *state, /* out */ size_t *packet_size); // Returns NULL for failure, or a TCP packet to be sent then freed with FFI_mitls_free_packet()
+extern int FFI_mitls_handle_server_hello(/* in out */ size_t *state, char* header, size_t header_size, char *record, size_t record_size);
+extern int FFI_mitls_handle_encrypted_extensions(/* in out */ size_t *state, char* header, size_t header_size, char *record, size_t record_size);
+extern int FFI_mitls_handle_certificate_verify12(/* in out */ size_t *state, char* header, size_t header_size, char *record, size_t record_size);
+extern int FFI_mitls_handle_certificate_verify13(/* in out */ size_t *state, char* header, size_t header_size, char *record, size_t record_size);
+extern int FFI_mitls_handle_server_key_exchange(/* in out */ size_t *state, char* header, size_t header_size, char *record, size_t record_size);
+extern int FFI_mitls_handle_server_hello_done(/* in out */ size_t *state, char* header, size_t header_size, char *record, size_t record_size);
+extern void * FFI_mitls_prepare_client_key_exchange(/* in out */ size_t *state, /* out */ size_t *packet_size); // Returns NULL for failure, or a TCP packet to be sent then freed with FFI_mitls_free_packet()
+extern void * FFI_mitls_prepare_change_cipher_spec(/* in out */ size_t *state, /* out */ size_t *packet_size);
+extern void * FFI_mitls_prepare_handshake(/* in out */ size_t *state, /* out */ size_t *packet_size);
+extern int FFI_mitls_handle_change_cipher_spec(/* in out */ size_t *state, char* header, size_t header_size, char *record, size_t record_size);
+extern int FFI_mitls_handle_server_finished(/* in out */ size_t *state, char* header, size_t header_size, char *record, size_t record_size);
+
+extern void * FFI_mitls_prepare_send(/* in out */ size_t *state, const void* buffer, size_t buffer_size, /* out */ size_t *packet_size); // Returns NULL for failure, or a TCP packet to be sent then freed with FFI_mitls_free_packet()
+extern void * FFI_mitls_handle_receive(/* in out */ size_t *state, char* header, size_t header_size, char *record, size_t record_size, /* out */ size_t *packet_size);     // Returns NULL for failure, a plaintext packet to be freed with FFI_mitls_free_packet()
+
+#endif // HEADER_MITLS_FFI_H

--- a/src/tls/test/TestClient13.fst
+++ b/src/tls/test/TestClient13.fst
@@ -12,6 +12,7 @@ open TLSConstants
 open TLSInfo
 open StreamAE
 open CoreCrypto
+open KeySchedule
 
 (* FlexRecord *)
 
@@ -82,7 +83,619 @@ let replace_keyshare ksl e =
   | TLSExtensions.E_keyShare _ -> TLSExtensions.E_keyShare (ClientKeyShare ksl)
   | x -> x 
 
-let main config host port =
+  
+(*****************************************************************************************)
+type ffiStateClientHello = {
+    csch_guard: string;
+    csch_config: config;
+    csch_ks: ks;
+    csch_log: bytes;
+    csch_lg: HandshakeLog.log;
+    }
+
+let newconfig pv peername =
+  if pv = "1.3" then
+    let sigPref = [CoreCrypto.RSASIG] in
+    let hashPref = [Hash CoreCrypto.SHA256] in
+    let sigAlgPrefs = sigAlgPref sigPref hashPref in
+    let l =         [ TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 ] in
+    let csn = cipherSuites_of_nameList l in
+     ({TLSInfo.defaultConfig with
+         minVer = TLS_1p3;
+         maxVer = TLS_1p3;
+         ciphersuites = csn;
+         peer_name = Some peername;
+         })
+  else
+    let l = [ TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 ] in
+    let csn = cipherSuites_of_nameList l in
+    ({TLSInfo.defaultConfig with
+         minVer = TLS_1p2;
+         maxVer = TLS_1p2;
+         ciphersuites = csn;
+         safe_resumption = true;
+         signatureAlgorithms = [(CoreCrypto.RSASIG, Hash CoreCrypto.SHA512); (CoreCrypto.RSASIG, Hash CoreCrypto.SHA384);(CoreCrypto.RSASIG, Hash CoreCrypto.SHA256)];
+         check_peer_certificate = false;
+         ca_file = "/cygdrive/c/Repos/mitls/data/CAFile.pem";
+         peer_name = Some peername;
+         })
+         
+val ffiConfig: string -> string -> ffiStateClientHello  
+let ffiConfig tlsversion hostname =
+  let config = newconfig tlsversion hostname in
+  let rid=new_region root in
+  let ks, cr = KeySchedule.create #rid Client in
+  let lg = HandshakeLog.create #rid in
+  let log = empty_bytes in
+  let state:ffiStateClientHello =
+  {
+    csch_guard = "CSCH";
+    csch_config = config;
+    csch_ks = ks;
+    csch_log = log;
+    csch_lg = lg;
+  } in
+  state
+
+(*****************************************************************************************)
+type ffiStateServerHello = {
+    cssh_guard: string;
+    cssh_config: config;
+    cssh_ks: ks;
+    cssh_log: bytes;
+    cssh_lg: HandshakeLog.log;
+    cssh_ch: HandshakeMessages.ch;
+    }
+        
+val ffiPrepareClientHello: ffiState:ffiStateClientHello -> (cbytes * ffiStateServerHello)
+let ffiPrepareClientHello ffiState =
+  let _ = (if not (ffiState.csch_guard = "CSCH") then IO.print_string ("Incorrect csch_guard "^ffiState.csch_guard^"\n")) in
+  let config = ffiState.csch_config in
+  let ks = ffiState.csch_ks in
+  let lg = ffiState.csch_lg in
+  let log = ffiState.csch_log in
+  let (ClientHello ch,chb) = Handshake.prepareClientHello config ks lg None None in
+  let pv = ch.ch_protocol_version in
+  let kex = TLSConstants.Kex_ECDHE in
+  let (str,hs,log) = makeHSRecord pv (ClientHello ch) log in
+  let r = Record.makePacket Content.Handshake pv hs in 
+  let newstate:ffiStateServerHello = {
+        cssh_guard = "CSSH";
+        cssh_config = config;
+        cssh_ks = ks;
+        cssh_log = log;
+        cssh_lg = lg;
+        cssh_ch = ch;
+    } in
+  (get_cbytes r, newstate)
+  
+(*****************************************************************************************)
+let rec really_check buf len = 
+    let lb = length buf in
+    if len = 0 then Correct buf
+    else if len = lb then Correct buf
+    else Error(AD_illegal_parameter,  "Unexpected buffer length")
+  
+let check_read header record pv =
+  match really_check header 5 with 
+  | Correct header -> (
+      match Record.parseHeader header with  (* contenType protocolVersion length *)
+      | Correct (ct,pv,len) -> (
+         match really_check record len with
+         | Correct payload  -> Correct (ct,pv,payload)
+         | Error e          -> Error e )
+      | Error e             -> Error e )
+  | Error e                 -> Error e
+  
+let handleHSRecord header record pv kex log = 
+match check_read header record pv with
+  | Error z -> Error z
+  | Correct(Content.Handshake,rpv,pl) -> Handshake.parseHandshakeMessages (Some pv) (Some kex) pl
+    
+type ffiStateCertificateVerify = {
+    cscv_guard: string;
+    cscv_config: config;
+    cscv_ks: ks;
+    cscv_log: bytes;
+    cscv_lg: HandshakeLog.log;
+    cscv_ch: HandshakeMessages.ch;
+    cscv_n:nego;
+    cscv_k: option KeySchedule.recordInstance;
+    cscv_sh:HandshakeMessages.sh;
+    }
+
+ let recvHSRecord2 header record pv kex log = 
+  let c = check_read header record pv in
+  match c with
+  | Error (x,z) -> IO.print_string (z^"\n"); failwith "error"
+  | Correct(Content.Handshake,rpv,pl) -> (
+    match Handshake.parseHandshakeMessages (Some pv) (Some kex) pl with
+    | Correct (rem,[(hs_msg,to_log)]) -> 
+     	      (IO.print_string ("Received HS("^(string_of_handshakeMessage hs_msg)^")\n");
+	       (hs_msg,log @| to_log))
+    | Error (x,z) -> IO.print_string (z^"\n"); failwith "error"
+    )
+  
+ let recvCCRecord2 header record pv kex log = 
+  let c = check_read header record pv in
+  match c with
+  | Error (x,z) -> IO.print_string (z^"\n"); failwith "error"
+  | Correct(Content.Change_cipher_spec,rpv,pl) -> (
+    match Handshake.parseHandshakeMessages (Some pv) (Some kex) pl with
+    | Correct (rem,[(hs_msg,to_log)]) -> 
+     	      (IO.print_string ("Received HS("^(string_of_handshakeMessage hs_msg)^")\n");
+	       (hs_msg,log @| to_log))
+    | Error (x,z) -> IO.print_string (z^"\n"); failwith "error"
+    )
+  
+val ffiHandleServerHelloWorker: ffiState:ffiStateServerHello -> header:cbytes -> record:cbytes -> (result (ffiStateCertificateVerify))
+let ffiHandleServerHelloWorker ffiState cheader crecord =
+  let _ = (if not (ffiState.cssh_guard = "CSSH") then IO.print_string ("Incorrect cssh_guard "^ffiState.cssh_guard^"\n")) in
+  let header = abytes cheader in
+  let record = abytes crecord in
+  let config = ffiState.cssh_config in
+  let log = ffiState.cssh_log in
+  let ch = ffiState.cssh_ch in
+  let lg = ffiState.cssh_lg in
+  let ks = ffiState.cssh_ks in
+  let kex = TLSConstants.Kex_ECDHE in
+  let pv = config.maxVer in
+  let ServerHello(sh),log = recvHSRecord2 header record pv kex log in
+  let Correct (n,k) = Handshake.processServerHello config ks lg None ch (ServerHello sh,log) in
+    match k with
+    | None -> let newstate:ffiStateCertificateVerify = {
+        cscv_guard = "CSCV";
+        cscv_config=config;
+        cscv_ch=ch;
+        cscv_ks=ks;
+        cscv_log=log;
+        cscv_lg=lg;
+        cscv_n=n;
+        cscv_k=None;
+        cscv_sh=sh;
+        } in Correct(newstate)
+    | Some kk -> let newstate:ffiStateCertificateVerify = {
+        cscv_guard = "CSCV";
+        cscv_config=config;
+        cscv_ch=ch;
+        cscv_ks=ks;
+        cscv_log=log;
+        cscv_lg=lg;
+        cscv_n=n;
+        cscv_k=Some kk;
+        cscv_sh=sh;
+        } in Correct(newstate)
+  
+  val ffiHandleServerHello: ffiState:ffiStateServerHello -> header:cbytes -> record:cbytes -> ffiStateCertificateVerify
+  let ffiHandleServerHello ffiState cheader crecord =
+    match ffiHandleServerHelloWorker ffiState cheader crecord with
+    | Error (x,z) -> IO.print_string (z^"\n"); failwith "error"
+    | Correct (x) -> x
+  
+(*****************************************************************************************)
+let handleEncHSRecord header record pv kex log rd = 
+match check_read header record pv with
+  | Error z -> Error z
+  | Correct(Content.Application_data,_,cipher) -> 
+      let payload = decryptRecord_TLS13_AES_GCM_128_SHA256 rd Content.Handshake cipher in
+                    Handshake.parseHandshakeMessages (Some pv) (Some kex) payload
+
+val ffiHandleEncryptedExtensionsWorker: ffiState:ffiStateCertificateVerify -> header:bytes -> record:bytes -> (result (ffiStateCertificateVerify))
+let ffiHandleEncryptedExtensionsWorker ffiState header record =
+  let _ = (if not (ffiState.cscv_guard = "CSCV") then IO.print_string ("Incorrect cssh_guard "^ffiState.cscv_guard^"\n")) in
+  let config = ffiState.cscv_config in
+  let log = ffiState.cscv_log in
+  let lg = ffiState.cscv_lg in
+  let ks = ffiState.cscv_ks in
+  let kex = TLSConstants.Kex_ECDHE in
+  let sh = ffiState.cscv_sh in
+  let pv = sh.sh_protocol_version in
+  match ffiState.cscv_k with
+  | k -> Error(AD_illegal_parameter,  "k must be not None here")
+  | Some k -> let KeySchedule.StAEInstance rd wr = k in
+      (match handleEncHSRecord header record pv kex log rd with
+        | Error z -> Error z
+        | Correct (rem,[(hs_msg,to_log)]) -> Correct(ffiState) (* bugbug: confirm this is an EncryptedExtensions(ee),log *)
+        | Correct (rem, hsm) -> Error (AD_illegal_parameter,  "Unexpected handleEncHSRecord rem hsm"))
+
+val ffiHandleEncryptedExtensions:  ffiState:ffiStateCertificateVerify -> header:cbytes -> record:cbytes -> ffiStateCertificateVerify
+let ffiHandleEncryptedExtensions ffiState header record =
+  let h = abytes header in
+  let r = abytes record in
+  match ffiHandleEncryptedExtensionsWorker ffiState h r with
+  | Error (x,z) -> IO.print_string (z^"\n"); failwith "error"
+  | Correct (x) -> x
+    
+(*****************************************************************************************)
+type ffiStateKeyExchange = {
+    cske_guard: string;
+    cske_config: config;
+    cske_ks: ks;
+    cske_log: bytes;
+    cske_lg: HandshakeLog.log;
+    cske_ch: HandshakeMessages.ch;
+    cske_n:nego;
+    cske_sc:HandshakeMessages.crt;
+    cske_sh:HandshakeMessages.sh;
+    cske_scb:bytes;
+    }
+
+val ffiHandleCertificateVerifyWorker12: ffiState:ffiStateCertificateVerify -> header:bytes -> record:bytes -> (result (ffiStateKeyExchange))
+let ffiHandleCertificateVerifyWorker12 ffiState header record =
+  let _ = (if not (ffiState.cscv_guard = "CSCV") then IO.print_string ("Incorrect cssh_guard "^ffiState.cscv_guard^"\n")) in
+  let config = ffiState.cscv_config in
+  let log = ffiState.cscv_log in
+  let sh = ffiState.cscv_sh in
+  let n = ffiState.cscv_n in
+  let pv = n.n_protocol_version in
+  let cs = n.n_cipher_suite in
+  let CipherSuite kex sa ae = cs in
+  match pv with
+    | TLS_1p2 -> (let (Certificate(sc),scb) = recvHSRecord2 header record pv kex log in
+                     IO.print_string ("Certificate validation status = " ^
+                       (if Cert.validate_chain sc.crt_chain true config.peer_name config.ca_file then
+                       "OK" else "FAIL")^"\n");
+                   let newstate:ffiStateKeyExchange = {
+                    cske_guard = "CSKE";
+                    cske_config = config;
+                    cske_ks = ffiState.cscv_ks;
+                    cske_log = log;
+                    cske_lg = ffiState.cscv_lg;
+                    cske_ch = ffiState.cscv_ch;
+                    cske_n = n;
+                    cske_sc = sc;
+                    cske_sh = sh;
+                    cske_scb = scb;
+                   } in
+                   Correct(newstate))
+    | _ -> Error(AD_illegal_parameter,  "Unsupported sh_protocol_version")
+  
+  
+val ffiHandleCertificateVerify12:  ffiState:ffiStateCertificateVerify -> header:cbytes -> record:cbytes -> ffiStateKeyExchange
+let ffiHandleCertificateVerify12 ffiState header record =
+  let h = abytes header in
+  let r = abytes record in
+  match ffiHandleCertificateVerifyWorker12 ffiState h r with
+  | Error (x,z) -> IO.print_string (z^"\n"); failwith "error"
+  | Correct (x) -> x
+    
+(*****************************************************************************************)
+val ffiHandleCertificateVerifyWorker13: ffiState:ffiStateCertificateVerify -> header:bytes -> record:bytes -> (result (ffiStateCertificateVerify))
+let ffiHandleCertificateVerifyWorker13 ffiState header record =
+  let _ = (if not (ffiState.cscv_guard = "CSCV") then IO.print_string ("Incorrect cssh_guard "^ffiState.cscv_guard^"\n")) in
+  let config = ffiState.cscv_config in
+  let log = ffiState.cscv_log in
+  let sh = ffiState.cscv_sh in
+  let n = ffiState.cscv_n in
+  let pv = n.n_protocol_version in
+  let cs = n.n_cipher_suite in
+  let CipherSuite kex sa ae = cs in
+  match pv with
+    | TLS_1p3 -> (match ffiState.cscv_k with
+                       | k -> Error(AD_illegal_parameter,  "k must be not None here")
+                       | Some k -> let KeySchedule.StAEInstance rd wr = k in
+                                   (match handleEncHSRecord header record pv kex log rd with
+                                          | Error z -> Error z
+                                          | Correct (rem,[(hs_msg,to_log)]) -> Correct(ffiState) (* bugbug: confirm this is a Certificate(sc),log *)
+                                          | Correct (rem, hsm) -> Error (AD_illegal_parameter,  "Unexpected handleEncHSRecord rem hsm")))
+    | _ -> Error(AD_illegal_parameter,  "Unsupported sh_protocol_version")
+  
+  
+val ffiHandleCertificateVerify13:  ffiState:ffiStateCertificateVerify -> header:cbytes -> record:cbytes -> ffiStateCertificateVerify
+let ffiHandleCertificateVerify13 ffiState header record =
+  let h = abytes header in
+  let r = abytes record in
+  match ffiHandleCertificateVerifyWorker13 ffiState h r with
+  | Error (x,z) -> IO.print_string (z^"\n"); failwith "error"
+  | Correct (x) -> x
+    
+(*****************************************************************************************)
+type ffiStateServerHelloDone = {
+    cssd_guard: string;
+    cssd_config: config;
+    cssd_ks: ks;
+    cssd_log: bytes;
+    cssd_lg: HandshakeLog.log;
+    cssd_ch: HandshakeMessages.ch;
+    cssd_n:nego;
+    cssd_sc:HandshakeMessages.crt;
+    cssd_scb: bytes;
+    cssd_sh:HandshakeMessages.sh;
+    cssd_ske:HandshakeMessages.ske;
+    cssd_skeb:bytes;
+    }
+    
+val ffiHandleServerKeyExchangeWorker: ffiState:ffiStateKeyExchange -> header:bytes -> record:bytes -> (result (ffiStateServerHelloDone))
+let ffiHandleServerKeyExchangeWorker ffiState header record =
+  let _ = (if not (ffiState.cske_guard = "CSKE") then IO.print_string ("Incorrect cske_guard "^ffiState.cske_guard^"\n")) in
+  let _ = (if not (ffiState.cske_n.n_protocol_version = TLS_1p2) then IO.print_string ("This call is for TLS 1.2 only\n")) in
+  let config = ffiState.cske_config in
+  let log = ffiState.cske_log in
+  let sh = ffiState.cske_sh in
+  let n = ffiState.cske_n in
+  let pv = n.n_protocol_version in
+  let cs = n.n_cipher_suite in
+  let CipherSuite kex sa ae = cs in
+  let (ServerKeyExchange(ske),skeb) = recvHSRecord2 header record pv kex log in
+  let newstate:ffiStateServerHelloDone = {
+        cssd_guard = "CSSD";
+        cssd_config = config;
+        cssd_ks = ffiState.cske_ks;
+        cssd_log = log;
+        cssd_lg = ffiState.cske_lg;
+        cssd_ch = ffiState.cske_ch;
+        cssd_n = n;
+        cssd_sc = ffiState.cske_sc;
+        cssd_sh = ffiState.cske_sh;
+        cssd_scb = ffiState.cske_scb;
+        cssd_sh = sh;
+        cssd_ske = ske;
+        cssd_skeb = skeb;
+        } in
+    Correct(newstate)
+  
+val ffiHandleServerKeyExchange:  ffiState:ffiStateKeyExchange -> header:cbytes -> record:cbytes -> ffiStateServerHelloDone
+let ffiHandleServerKeyExchange ffiState header record =
+  let h = abytes header in
+  let r = abytes record in
+  match ffiHandleServerKeyExchangeWorker ffiState h r with
+  | Error (x,z) -> IO.print_string (z^"\n"); failwith "error"
+  | Correct (x) -> x
+    
+(*****************************************************************************************)
+type ffiStateClientKeyExchange = {
+    csck_guard: string;
+    csck_config: config;
+    csck_log: bytes;
+    csck_lg: HandshakeLog.log;
+    csck_n:nego;
+    csck_ks: ks;
+    csck_cke: HandshakeMessages.cke;
+    csck_ckeb: bytes;
+}
+
+val ffiHandleServerHelloDoneWorker: ffiState:ffiStateServerHelloDone -> header:bytes -> record:bytes -> (result (ffiStateClientKeyExchange))
+let ffiHandleServerHelloDoneWorker ffiState header record =
+  let _ = (if not (ffiState.cssd_guard = "CSSD") then IO.print_string ("Incorrect cssd_guard "^ffiState.cssd_guard^"\n")) in
+  let _ = (if not (ffiState.cssd_n.n_protocol_version = TLS_1p2) then IO.print_string ("This call is for TLS 1.2 only\n")) in
+  let config = ffiState.cssd_config in
+  let log = ffiState.cssd_log in
+  let lg = ffiState.cssd_lg in
+  let n = ffiState.cssd_n in
+  let pv = n.n_protocol_version in
+  let cs = n.n_cipher_suite in
+  let CipherSuite kex sa ae = cs in
+  let (ServerHelloDone,shdb) = recvHSRecord2 header record pv kex log in
+
+  let ske = ffiState.cssd_ske in
+  let skeb = ffiState.cssd_skeb in
+  let tbs = kex_s_to_bytes ske.ske_kex_s in
+  let sigv = ske.ske_sig in
+  let ch = ffiState.cssd_ch in
+  let cr = ch.ch_client_random in
+  let sh = ffiState.cssd_sh in
+  let sr = sh.sh_server_random in
+  let scb = ffiState.cssd_scb in
+  let ks = ffiState.cssd_ks in
+  let sc = ffiState.cssd_sc in
+  let (ClientKeyExchange cke,ckeb) = 
+     match
+       Handshake.processServerHelloDone config n ks lg
+      	[(Certificate sc,scb);(ServerKeyExchange ske, skeb);(ServerHelloDone,shdb)]
+	[] with
+     | Correct [x] -> x 
+     | Error (y,z) -> failwith (z ^ "\n") in
+   let newstate:ffiStateClientKeyExchange = {
+    csck_guard = "CSCK";
+    csck_config = config;
+    csck_log = log;
+    csck_lg = lg;
+    csck_n = n;
+    csck_ks = ffiState.cssd_ks;
+    csck_cke = cke;
+    csck_ckeb = ckeb;
+   } in
+   Correct(newstate)
+
+val ffiHandleServerHelloDone:  ffiState:ffiStateServerHelloDone -> header:cbytes -> record:cbytes -> ffiStateClientKeyExchange
+let ffiHandleServerHelloDone ffiState header record =
+  let h = abytes header in
+  let r = abytes record in
+  match ffiHandleServerHelloDoneWorker ffiState h r with
+  | Error (x,z) -> IO.print_string (z^"\n"); failwith "error"
+  | Correct (x) -> (x)
+    
+(*****************************************************************************************)
+let sendRecord2 pv ct msg str = 
+  let r = Record.makePacket ct pv msg in
+  (*let _ = (match ct with
+  | Content.Application_data ->   IO.print_string ("Sending Data("^str^")\n")
+  | Content.Handshake ->   IO.print_string ("Sending HS("^str^")\n")
+  | Content.Change_cipher_spec ->   IO.print_string ("Sending CCS\n")
+  | Content.Alert ->   IO.print_string ("Sending Alert("^str^")\n")) in  *)
+  r
+ 
+let sendHSRecord2 pv (m,b) = 
+  let str = string_of_handshakeMessage m in
+  sendRecord2 pv Content.Handshake b str
+
+val ffiPrepareClientKeyExchange:  ffiState:ffiStateClientKeyExchange -> (cbytes * ffiStateClientKeyExchange)
+let ffiPrepareClientKeyExchange ffiState =
+  let _ = (if not (ffiState.csck_guard = "CSCK") then IO.print_string ("Incorrect csck_guard "^ffiState.csck_guard^"\n")) in
+  let _ = (if not (ffiState.csck_n.n_protocol_version = TLS_1p2) then IO.print_string ("This call is for TLS 1.2 only\n")) in
+  let n = ffiState.csck_n in
+  let pv = n.n_protocol_version in
+  let cke = ffiState.csck_cke in
+  let ckeb = ffiState.csck_ckeb in
+  let r = Record.makePacket Content.Handshake pv ckeb in
+  (get_cbytes r, ffiState)
+
+(*****************************************************************************************)
+type ffiStateHandshake = {
+    cshs_guard: string;
+    cshs_config: config;
+    cshs_log: bytes;
+    cshs_lg: HandshakeLog.log;
+    cshs_ks: ks;
+    cshs_n:nego;
+    cshs_wr: (StatefulLHAE.writer TestClient.id);
+    cshs_rd: (StatefulLHAE.reader TestClient.id);
+    cshs_efinb: bytes;
+    cshs_str: string;
+}
+
+
+val ffiPrepareChangeCipherSpec:  ffiState:ffiStateClientKeyExchange -> (cbytes * ffiStateHandshake)
+let ffiPrepareChangeCipherSpec ffiState =
+  let _ = (if not (ffiState.csck_guard = "CSCK") then IO.print_string ("Incorrect csck_guard "^ffiState.csck_guard^"\n")) in
+  let _ = (if not (ffiState.csck_n.n_protocol_version = TLS_1p2) then IO.print_string ("This call is for TLS 1.2 only\n")) in
+  let log = ffiState.csck_lg in
+  let n = ffiState.csck_n in
+  let pv = n.n_protocol_version in
+  let ks = ffiState.csck_ks in
+  let ems = n.n_extensions.ne_extended_ms in
+  let sal = n.n_extensions.ne_signature_algorithms in
+  
+  let lb = HandshakeLog.getBytes log in
+  (* if ems then IO.print_string " ***** USING EXTENDED MASTER SECRET ***** \n";
+//  IO.print_string ("master secret:"^(Platform.Bytes.print_bytes ms)^"\n"); *)
+  let (ck, civ, sk, siv) = KeySchedule.ks_12_get_keys ks in
+  (*IO.print_string ("client AES_GCM write key:"^(Platform.Bytes.print_bytes ck)^"\n");
+  IO.print_string ("client AES_GCM salt: iv:"^(Platform.Bytes.print_bytes civ)^"\n");
+  IO.print_string ("server AES_GCM write key:"^(Platform.Bytes.print_bytes sk)^"\n");
+  IO.print_string ("server AES_GCM salt:"^(Platform.Bytes.print_bytes siv)^"\n"); *)
+  let wr = TestClient.encryptor_TLS12_AES_GCM_128_SHA256 ck civ in
+  let rd = TestClient.decryptor_TLS12_AES_GCM_128_SHA256 sk siv in
+
+  let (Finished cfin, cfinb) = Handshake.prepareClientFinished ks log in
+  let str = string_of_handshakeMessage (Finished cfin) in 
+  let efinb = TestClient.encryptRecord_TLS12_AES_GCM_128_SHA256 wr Content.Handshake cfinb in
+  let r = sendRecord2 pv Content.Change_cipher_spec HandshakeMessages.ccsBytes "Client" in
+  let newstate:ffiStateHandshake = {
+    cshs_guard="CSHS";
+    cshs_config=ffiState.csck_config;
+    cshs_log=ffiState.csck_log;
+    cshs_lg=log;
+    cshs_ks=ffiState.csck_ks;
+    cshs_n=ffiState.csck_n;
+    cshs_wr = wr;
+    cshs_rd = rd;
+    cshs_efinb = efinb;
+    cshs_str = str;
+  } in
+  (get_cbytes r, newstate)
+  
+val ffiPrepareHandshake:  ffiState:ffiStateHandshake -> (cbytes * ffiStateHandshake)
+let ffiPrepareHandshake ffiState =
+  let _ = (if not (ffiState.cshs_guard = "CSHS") then IO.print_string ("Incorrect cshs_guard "^ffiState.cshs_guard^"\n")) in
+  let _ = (if not (ffiState.cshs_n.n_protocol_version = TLS_1p2) then IO.print_string ("This call is for TLS 1.2 only\n")) in
+  let n = ffiState.cshs_n in
+  let pv = n.n_protocol_version in
+  let r = sendRecord2 pv Content.Handshake ffiState.cshs_efinb ffiState.cshs_str in
+  (get_cbytes r, ffiState)
+
+(*****************************************************************************************)
+val ffiHandleChangeCipherSpecWorker: ffiState:ffiStateHandshake -> header:bytes -> record:bytes -> (result (ffiStateHandshake))
+let ffiHandleChangeCipherSpecWorker ffiState header record =
+  let _ = (if not (ffiState.cshs_guard = "CSHS") then IO.print_string ("Incorrect cske_guard "^ffiState.cshs_guard^"\n")) in
+  let _ = (if not (ffiState.cshs_n.n_protocol_version = TLS_1p2) then IO.print_string ("This call is for TLS 1.2 only\n")) in
+  let config = ffiState.cshs_config in
+  let log = ffiState.cshs_log in
+  let n = ffiState.cshs_n in
+  let pv = n.n_protocol_version in
+  let cs = n.n_cipher_suite in
+  let CipherSuite kex sa ae = cs in
+  let c = check_read header record pv in
+  match c with
+  | Error (x,z) -> IO.print_string (z^"\n"); Error (x,z)
+  | Correct(Content.Change_cipher_spec,rpv,pl) -> Correct(ffiState)
+  
+val ffiHandleChangeCipherSpec:  ffiState:ffiStateHandshake -> header:cbytes -> record:cbytes -> ffiStateHandshake
+let ffiHandleChangeCipherSpec ffiState header record =
+  let h = abytes header in
+  let r = abytes record in
+  match ffiHandleChangeCipherSpecWorker ffiState h r with
+  | Error (x,z) -> IO.print_string (z^"\n"); failwith "error"
+  | Correct (x) -> x
+    
+(*****************************************************************************************)
+let recvEncHSRecord2 header record pv kex log rd = 
+  let Correct(Content.Handshake,_,cipher) = check_read header record pv in
+  let payload = TestClient.decryptRecord_TLS12_AES_GCM_128_SHA256 rd Content.Handshake cipher in
+  let Correct (rem,hsm) = Handshake.parseHandshakeMessages (Some pv) (Some kex) payload in
+  let [(hs_msg,to_log)] = hsm in
+  IO.print_string ("Received HS("^(string_of_handshakeMessage hs_msg)^")\n");
+  let logged = handshakeMessageBytes (Some pv) hs_msg in
+  IO.print_string ("Logged message = Parsed message? ");
+  if (Platform.Bytes.equalBytes logged to_log) then IO.print_string "yes\n" else IO.print_string "no\n";
+  hs_msg,to_log
+
+val ffiHandleServerFinishedWorker: ffiState:ffiStateHandshake -> header:bytes -> record:bytes -> (result (ffiStateHandshake))
+let ffiHandleServerFinishedWorker ffiState header record =
+  let _ = (if not (ffiState.cshs_guard = "CSHS") then IO.print_string ("Incorrect cske_guard "^ffiState.cshs_guard^"\n")) in
+  let _ = (if not (ffiState.cshs_n.n_protocol_version = TLS_1p2) then IO.print_string ("This call is for TLS 1.2 only\n")) in
+  let config = ffiState.cshs_config in
+  let log = ffiState.cshs_log in
+  let n = ffiState.cshs_n in
+  let pv = n.n_protocol_version in
+  let cs = n.n_cipher_suite in
+  let CipherSuite kex sa ae = cs in
+  let rd = ffiState.cshs_rd in
+  let ks = ffiState.cshs_ks in
+  let lg = ffiState.cshs_lg in
+  let (Finished(sfin),sfinb) = recvEncHSRecord2 header record pv kex lg rd in
+  let Correct svd = Handshake.processServerFinished ks lg (Finished sfin, sfinb) in
+  (*IO.print_string ("Recd fin = expected fin? ");
+  if (Platform.Bytes.equalBytes sfin.fin_vd svd) then IO.print_string "yes\n" else IO.print_string "no\n"; *)
+  Correct(ffiState)
+  
+val ffiHandleServerFinished:  ffiState:ffiStateHandshake -> header:cbytes -> record:cbytes -> ffiStateHandshake
+let ffiHandleServerFinished ffiState header record =
+  let h = abytes header in
+  let r = abytes record in
+  match ffiHandleServerFinishedWorker ffiState h r with
+  | Error (x,z) -> IO.print_string (z^"\n"); failwith "error"
+  | Correct (x) -> x
+    
+(*****************************************************************************************)
+val ffiPrepareSend:  ffiState:ffiStateHandshake -> cbytes -> cbytes
+let ffiPrepareSend ffiState payload =
+  let _ = (if not (ffiState.cshs_guard = "CSHS") then IO.print_string ("Incorrect cshs_guard "^ffiState.cshs_guard^"\n")) in
+  let _ = (if not (ffiState.cshs_n.n_protocol_version = TLS_1p2) then IO.print_string ("This call is for TLS 1.2 only\n")) in
+  let n = ffiState.cshs_n in
+  let pv = n.n_protocol_version in
+  let wr = ffiState.cshs_wr in
+  let msg = TestClient.encryptRecord_TLS12_AES_GCM_128_SHA256 wr Content.Application_data (utf8 payload) in
+  let r = sendRecord2 pv Content.Application_data msg "Send" in
+  get_cbytes r
+(*****************************************************************************************)
+   
+val ffiHandleReceiveWorker: ffiState:ffiStateHandshake -> header:bytes -> record:bytes -> (result (bytes))
+let ffiHandleReceiveWorker ffiState header record =
+  let _ = (if not (ffiState.cshs_guard = "CSHS") then IO.print_string ("Incorrect cske_guard "^ffiState.cshs_guard^"\n")) in
+  let _ = (if not (ffiState.cshs_n.n_protocol_version = TLS_1p2) then IO.print_string ("This call is for TLS 1.2 only\n")) in
+  let config = ffiState.cshs_config in
+  let n = ffiState.cshs_n in
+  let pv = n.n_protocol_version in
+  let rd = ffiState.cshs_rd in
+  let c = check_read header record pv in
+  match c with
+  | Error (x,z) -> IO.print_string (z^"\n"); Error (x,z)
+  | Correct(Content.Application_data,_,cipher) -> 
+      let cleartext = TestClient.decryptRecord_TLS12_AES_GCM_128_SHA256 rd Content.Application_data cipher in
+      Correct (cleartext)
+      
+  
+val ffiHandleReceive:  ffiState:ffiStateHandshake -> header:cbytes -> record:cbytes -> cbytes
+let ffiHandleReceive ffiState header record =
+  let h = abytes header in
+  let r = abytes record in
+  match ffiHandleReceiveWorker ffiState h r with
+  | Error (x,z) -> IO.print_string (z^"\n"); failwith "error"
+  | Correct (x) -> get_cbytes x 
+  
+(*****************************************************************************************)
+  let main config host port =
   IO.print_string "===============================================\n Starting test TLS client...\n";
   let tcp = Platform.Tcp.connect host port in
   let log = empty_bytes in
@@ -143,4 +756,3 @@ let main config host port =
   sendRecord tcp pv Content.Application_data get "GET /";
   let ad = recvEncAppDataRecord tcp pv drd in
   ()
-


### PR DESCRIPTION
Add C-callable wrappers to miTLS, callable from curl or other TLS
clients and servers.  This generates a libmitls.dll that contains miTLS and C-callable entrypoints.

At this point, it works well enough to negotiate TLS 1.2 to web page URLs on google.com and fetch their contents.

**Future work**
- TLS 1.3 support
- remove the IO.print_string calls from the miTLS "expected" codepaths (possibly by wrapping them, so they are available, but don't print in the retail build).  They currently interfere with using curl to download web pages, as it dumps the downloaded content to stdout.
- reduce fragility of the "state" object on the C side by removing the need to make the caller's storage a GC root.  The next version will store a C heap pointer in the caller's buffer, and make the C heap allocation a GC root.  The extra level of indirection adds safety at minimal size/speed overhead.
- sync my branch forward to the main branch... my branch is 3 weeks stale
- improve performance via caller-allocated buffers instead of the FFI layer using malloc() to allocate new packet buffers.

**To review**, I recommend the following order:
1. Start with mitlsffi.h - that defines the C-callable interface into miTLS.  
2. Then head to FFI.ml to see the FStar side of that interface.  
3.  ffi.c contains the glue code between the two worlds, using the OCaml FFI to allocate memory, call functions, etc.
4.  TestClient13.fst has expanded considerably - it implements the miTLS side of TLS.  The new code is almost all cloned code from TestClient and TestClient13, wrapped in glue code to marshal and unmarshal state.

**Questions for the team**
1. Should I refactor the ffi code out of TestClient13.fst into a separate ffi.fst file?  
2. Is there a better way to capture and replay state than the many "ffiState*" structs I created?  The process of creating them was tedious and error-prone, especially deducing the types of each field.