### PR TITLE
sishtiaq_ifdebug

### DIFF
--- a/src/tls/Handshake.fst
+++ b/src/tls/Handshake.fst
@@ -34,6 +34,11 @@ module MS = FStar.Monotonic.Seq
 //<expose for TestClient>
 #set-options "--lax"
 
+(* A flag for runtime debugging of computed keys.
+   The F* normalizer will erase debug prints at extraction
+   when this false is set to flag *)
+let hs_debug = false
+
 val prepareClientHello: config -> KeySchedule.ks -> HandshakeLog.log -> option ri -> option sessionID -> ST (hs_msg * bytes)
   (requires (fun h -> True))
   (ensures (fun h0 i h1 -> True))
@@ -537,7 +542,10 @@ let processServerHelloDone cfg n ks log msgs opt_msgs =
            | Some pk ->
 	     let valid = Signature.verify #a h pk tbs sigv in
 	     //let _ = IO.debug_print_string("tbs = " ^ (Platform.Bytes.print_bytes tbs) ^ "\n") in
-	     let _ = IO.debug_print_string("Signature validation status = " ^ (if valid then "OK" else "FAIL") ^ "\n") in
+	     let _ = 
+        if hs_debug then 
+          IO.debug_print_string("Signature validation status = " ^ (if valid then "OK" else "FAIL") ^ "\n") 
+        else false in
 	     if valid then
 	       begin
                match ske.ske_kex_s with
@@ -712,7 +720,10 @@ let processServerFinished_13 cfg n ks log msgs =
            match Signature.get_chain_public_key #a c.crt_chain with
            | Some pk ->
              let valid = Signature.verify ha pk tbs sigv in
-             let _ = IO.debug_print_string("Signature validation status = " ^ (if valid then "OK" else "FAIL") ^ "\n") in
+             let _ = 
+              if hs_debug then
+                IO.debug_print_string("Signature validation status = " ^ (if valid then "OK" else "FAIL") ^ "\n")
+              else false in
              if valid then
                let _ = log @@ CertificateVerify(cv) in
                let svd = KeySchedule.ks_client_13_server_finished ks in
@@ -1196,7 +1207,10 @@ let rec next_fragment i hs =
           | None -> false
           | Some Reader -> Epochs.incr_reader lgref; true // possibly used by server in 0-RT
           | Some Writer -> Epochs.incr_writer lgref; true in
-       let tbb = IO.debug_print_string (" *** WRITE "^(print_bytes b)^"\n") in
+       let tbb = 
+        if hs_debug then 
+          IO.debug_print_string (" *** WRITE "^(print_bytes b)^"\n")
+        else false in
        hsref := {!hsref with
          hs_buffers = {(!hsref).hs_buffers with
            hs_outgoing = empty_bytes;
@@ -1271,7 +1285,10 @@ val recv_fragment: s:hs -> #i:id -> message i -> ST incoming
   (ensures (recv_ensures s))
 let recv_fragment hs #i f = 
     let (| rg,rb |) = f in
-    let b = IO.debug_print_string ("   ***** RAW "^(print_bytes rb)^"\n") in
+    let b = 
+      if hs_debug then
+        IO.debug_print_string ("   ***** RAW "^(print_bytes rb)^"\n")
+      else false in
     let (HS #r0 r res cfg id lgref hsref) = hs in
     let b = (!hsref).hs_buffers.hs_incoming in
     let b = b @| rb in
@@ -1281,16 +1298,26 @@ let recv_fragment hs #i f =
        | Some n -> Some n.n_protocol_version, Some n.n_kexAlg, Some n.n_resume) in
     match parseHandshakeMessages pv kex b with
     | Error (ad, s) ->
-      let _ = IO.debug_print_string ("Failed to parse message: "^(string_of_ad ad)^": "^s^"\n") in InError (ad,s)
+      let _ = 
+        if hs_debug then
+          IO.debug_print_string ("Failed to parse message: "^(string_of_ad ad)^": "^s^"\n")
+        else false in 
+      InError (ad,s)
     | Correct(r,hsl) ->
        let hsl = List.Tot.append (!hsref).hs_buffers.hs_incoming_parsed hsl in
        hsref := {!hsref with hs_buffers = {(!hsref).hs_buffers with hs_incoming = r; hs_incoming_parsed = hsl}};
-      let b = print_hsl hsl in
+      let b = 
+        if hs_debug then 
+          print_hsl hsl 
+        else false in
       (match (!hsref).hs_state,hsl with 
        | C (C_Idle ri), _ -> InError(AD_unexpected_message, "Client hasn't sent hello yet")
        | C (C_HelloSent ri ch), (ServerHello(sh),l)::hsl 
 	 when (sh.sh_protocol_version <> TLS_1p3 || hsl = []) ->
-           let _ = IO.debug_print_string "Processing client hello...\n" in
+           let _ = 
+            if hs_debug then
+              IO.debug_print_string "Processing client hello...\n"
+            else false in
 	   hsref := {!hsref with hs_buffers = {(!hsref).hs_buffers with hs_incoming_parsed = hsl}};
 	   client_handle_server_hello hs [(ServerHello(sh),l)]
        | C (C_HelloReceived n), (Certificate(c),l)::
@@ -1388,7 +1415,10 @@ val recv_ccs: s:hs -> ST incoming  // special case: CCS before 1p3; could merge 
     (is_InError result \/ result = InAck true false)
     ))
 let recv_ccs hs =
-    let b = IO.debug_print_string ("CALL recv_ccs\n") in
+    let b = 
+      if hs_debug then 
+        IO.debug_print_string ("CALL recv_ccs\n")
+      else false in
     let (HS #r0 r res cfg id lgref hsref) = hs in
     let pv,kex = 
       (match (!hsref).hs_nego with 

--- a/src/tls/Handshake.fst
+++ b/src/tls/Handshake.fst
@@ -34,7 +34,7 @@ module MS = FStar.Monotonic.Seq
 //<expose for TestClient>
 #set-options "--lax"
 
-(* A flag for runtime debugging of computed keys.
+(* A flag for runtime debugging of Handshake data. 
    The F* normalizer will erase debug prints at extraction
    when this false is set to flag *)
 let hs_debug = false

--- a/src/tls/TLS.fst
+++ b/src/tls/TLS.fst
@@ -30,6 +30,11 @@ module SD   = StreamDeltas
 module Conn = Connection
 module EP   = Epochs
 
+(* A flag for runtime debugging of computed keys.
+   The F* normalizer will erase debug prints at extraction
+   when this false is set to flag *)
+let tls_debug = false
+
 unfold let op_Array_Access (#a:Type) (s:Seq.seq a) n = Seq.index s n
 
 // using also DataStream, Content, Record
@@ -400,9 +405,11 @@ let sendFragment c #i wo f =
   let ct, rg = Content.ct_rg i f in
 
   let idt = if is_ID12 i then "ID12" else if is_ID13 i then "ID13" else "PlaintextID" in
-  let b = IO.debug_print_string 
-    ("sendFragment with index "^idt^" and content "^Content.ctToString ct^"\n") in
-
+  let _b = 
+    if tls_debug then 
+      IO.debug_print_string 
+        ("sendFragment with index "^idt^" and content "^Content.ctToString ct^"\n") 
+    else false in 
   if not (check_incrementable wo)
   then ad_overflow 
   else begin
@@ -522,7 +529,10 @@ private let sendHandshake (#c:connection) (#i:id) (wopt:option (cwriter i c)) (o
 		sendFragment_inv wopt h1
 		/\ sendHandshake_post wopt om send_ccs h0 r h1))
   =  let h0 = ST.get() in
-     let b = IO.debug_print_string "CALL sendHandshake\n" in
+     let _b = 
+      if tls_debug then 
+        IO.debug_print_string "CALL sendHandshake\n" 
+      else false in
      let result0 = // first try to send handshake fragment, if any
          match om with
          | None             -> Correct()
@@ -601,7 +611,10 @@ let next_fragment i c =
 		 FStar.SeqProperties.contains_intro (MS.i_sel h0 ilog) w0 (MS.i_sel h0 ilog).(w0);
 	         MR.witness ilog (MS.i_at_least w0 (MS.i_sel h0 ilog).(w0) ilog)) in
   let idt = if is_ID12 i then "ID12" else (if is_ID13 i then "ID13" else "PlaintextID") in
-  let b = IO.debug_print_string ("nextFragment index type "^idt^"\n") in
+  let _b = 
+    if tls_debug then 
+      IO.debug_print_string ("nextFragment index type "^idt^"\n") 
+    else false in
   let res = Handshake.next_fragment i s in
   let _ = if w0 >= 0
 	  then MR.testify (MS.i_at_least w0 (MS.i_sel h0 ilog).(w0) ilog) in
@@ -658,7 +671,10 @@ let rec writeHandshake h_init c new_writer =
   reveal_epoch_region_inv_all ();
   let i = currentId c Writer in
   let wopt = current_writer c i in
-  let _ = IO.debug_print_string ("CALL writeHandshake (wopt = "^(if is_None wopt then "None" else "Some")^")\n") in
+  let _ = 
+    if tls_debug then 
+      IO.debug_print_string ("CALL writeHandshake (wopt = "^(if is_None wopt then "None" else "Some")^")\n") 
+    else false in
   (* let h0 = get() in  *)
   match next_fragment i c with
   | Handshake.OutError (ad,reason) -> sendAlert c ad reason
@@ -666,7 +682,10 @@ let rec writeHandshake h_init c new_writer =
       //From Handshake.next_fragment ensures, we know that if next_keys = false
       //then current_writer didn't change;
       //We also know that this only modifies the handshake region, so the delta logs didn't change
-      let _ = IO.debug_print_string ("next_fragment: next_keys="^(if next_keys then "yes" else "no")^" complete ="^(if complete then "yes\n" else "no\n")) in
+      let _ = 
+        if tls_debug then 
+          IO.debug_print_string ("next_fragment: next_keys="^(if next_keys then "yes" else "no")^" complete ="^(if complete then "yes\n" else "no\n")) 
+        else false in
       match sendHandshake wopt om send_ccs with  //as a post-condition of sendHandshake, we know that the deltas didn't change
       | Error (ad,reason) -> 
 	recall_current_writer c;
@@ -957,7 +976,10 @@ END OLDER VARIANT *)
 // We notify, and hope to get back the peer's notify.
 
 let writeCloseNotify c =
-  let b = IO.debug_print_string "writeCloseNotify\n" in
+  let _b = 
+    if tls_debug then 
+      IO.debug_print_string "writeCloseNotify\n"
+    else false in
   sendAlert c AD_close_notify "full shutdown"
 
 // We notify and don't wait for confirmation.
@@ -1100,7 +1122,10 @@ let readFragment c i =
   | Correct(ct,pv,payload) ->
     let es = MR.m_read (MkEpochs.es c.hs.log) in
     let j : logIndex es = Handshake.i c.hs Reader in
-    let b = IO.debug_print_string ("Epoch index: "^(string_of_int j)^"\n") in
+    let _b = 
+      if tls_debug then
+        IO.debug_print_string ("Epoch index: "^(string_of_int j)^"\n") 
+      else false in
     if j < 0 then // payload is in plaintext
       let rg = Range.point (length payload) in
       Correct(Content.mk_fragment i ct rg payload)
@@ -1109,7 +1134,11 @@ let readFragment c i =
       let e = Seq.index es j in
       let Epoch #r #n #i hs rd wr = e in
       match StAE.decrypt (reader_epoch e) (ct,payload) with
-      | Some f -> let b = IO.debug_print_string "StAE decrypt correct.\n" in Correct f
+      | Some f -> let b = 
+                    if tls_debug then 
+                      IO.debug_print_string "StAE decrypt correct.\n" 
+                    else false in 
+                    Correct f
       | None   -> Error(AD_internal_error,"") //16-05-19 adjust!
 
 // We receive, decrypt, parse a record (ct,f); what to do with it?
@@ -1142,7 +1171,10 @@ let readOne c i =
 
   | Correct(Content.CT_Handshake rg f) ->
       begin
-        let b = IO.debug_print_string "readOne: CT_Handshake, calling recv_fragment...\n" in
+        let _b = 
+          if tls_debug then 
+            IO.debug_print_string "readOne: CT_Handshake, calling recv_fragment...\n" 
+          else false in
         match recv_fragment c.hs (| rg, f |) with
         | InError (x,y) -> alertFlush c i x y
         | InQuery q a   -> CertQuery q a
@@ -1167,7 +1199,10 @@ let readOne c i =
       end
   | Correct(Content.CT_Data rg f) ->
       begin
-        let b = IO.debug_print_string "readOne: CT_Data\n" in
+        let _b = 
+          if tls_debug then
+            IO.debug_print_string "readOne: CT_Data\n" 
+          else false in
         match !c.state with
         | AD | Half Reader        -> let f : DataStream.fragment i fragment_range = f in Read #i (DataStream.Data f)
         | _                       -> alertFlush c i AD_unexpected_message "Application Data received in wrong state"
@@ -1186,7 +1221,10 @@ let rec read c i =
     | WriteError x y             -> ReadError x y           // TODO review errors; check this is not ambiguous
     | WriteClose                  -> unexpected "Sent Close" // can't happen while sending?
     | WrittenHS newWriter complete ->
-        let b = IO.debug_print_string ("read: WrittenHS, "^(if newWriter then "newWriter" else "oldWriter")^" \n") in
+        let _b = 
+          if tls_debug then
+            IO.debug_print_string ("read: WrittenHS, "^(if newWriter then "newWriter" else "oldWriter")^" \n") 
+          else false in
         if complete then Complete // return at once, so that the app can authorize and use new indexes.
         // else ... then                // return at once, signalling falsestart
         else

--- a/src/tls/TLS.fst
+++ b/src/tls/TLS.fst
@@ -30,7 +30,7 @@ module SD   = StreamDeltas
 module Conn = Connection
 module EP   = Epochs
 
-(* A flag for runtime debugging of computed keys.
+(* A flag for runtime debugging of TLS data. 
    The F* normalizer will erase debug prints at extraction
    when this false is set to flag *)
 let tls_debug = false


### PR DESCRIPTION
In a module, use the module_debug flag to gate the call to IO.print_debug_string. 