### PR TITLE
Lens parens are reserved for dependent pair terms, not types

### DIFF
--- a/src/tls/Encode.fst
+++ b/src/tls/Encode.fst
@@ -37,7 +37,7 @@ private type plain (i:id) (ad: LHAEPlain.adata i) (rg:range) = | Plain:
   plain i ad rg 
 
 // should we index just by plaintext lengths, rather than ad & range?
-type dplain (i:id) (l:nat {valid_clen i l}) = (| ad:LHAEPlain.adata i &  plain i ad (cipherRangeClass i l) |)
+type dplain (i:id) (l:nat {valid_clen i l}) = ( ad:LHAEPlain.adata i &  plain i ad (cipherRangeClass i l) )
 
 val plainLength: i:id -> clen: nat { clen >= ivSize i } -> Tot nat
 let plainLength i clen = clen - ivSize i

--- a/src/tls/Handshake.fst
+++ b/src/tls/Handshake.fst
@@ -401,7 +401,7 @@ let handshake_state_init cfg (r:role) (reg:rid) =
     	| Server -> S (S_Idle None)) }
 
 // payload of a handshake fragment, to be made opaque eventually
-type message (i:id) = (| rg: frange i & rbytes rg |)
+type message (i:id) = ( rg: frange i & rbytes rg )
 let out_msg i rg b : message i= (|rg, b|)
 
 // What the HS asks the record layer to do, in that order.

--- a/src/tls/HandshakeLog.fst
+++ b/src/tls/HandshakeLog.fst
@@ -4,7 +4,7 @@ open FStar.HyperHeap
 open FStar.HyperStack
 open FStar.Seq
 open FStar.SeqProperties // for e.g. found
-open FStar.Set  
+open FStar.Set
 open Platform.Error
 open Platform.Bytes
 
@@ -23,7 +23,7 @@ let reveal_hs_log (hsl:hs_log) : GTot (list hs_msg) = hsl
 let hide_hs_log (l:list hs_msg) : GTot hs_log = l
 
 val validLog: hs_log -> Tot bool
-let validLog hsl = 
+let validLog hsl =
     match hsl with
     | [] -> true
     | [ClientHello ch] -> true
@@ -48,12 +48,12 @@ let getLogVersion hsl =
  * AR: changing logref from rref to HS.ref, with region captured in the refinement.
  *)
 noeq type log =
-  | LOG: #region:rid -> 
-         logref:ref (|
+  | LOG: #region:rid ->
+         logref:ref (
               pv: option protocolVersion
             & (hsl:hs_log{validLog hsl})
             &   b: bytes {getLogVersion hsl = pv /\ handshakeMessagesBytes pv (reveal_hs_log hsl) = b}
-         |){logref.id = region} -> log 
+         ){logref.id = region} -> log
 
 val create: #reg:rid -> ST log
   (requires (fun h -> True))
@@ -63,7 +63,7 @@ val create: #reg:rid -> ST log
     extends r reg /\
     modifies (Set.singleton r) h0 h1 /\
     modifies_rref r !{as_ref lr} h0.h h1.h))
-let create #reg = 
+let create #reg =
     let hsl: hs_log = [] in
     let r = new_region reg in
     let lr = ralloc r (| None, hsl, empty_bytes|) in
@@ -77,8 +77,8 @@ val append_log: l:log -> hm:hs_msg -> ST bytes
       let LOG #r lr = l in
       modifies (Set.singleton r) h0 h1
       /\ modifies_rref r !{as_ref lr} h0.h h1.h))
-let append_log (LOG #reg lref) hm = 
-    let (| pv, hsl, lb |) = !lref in 
+let append_log (LOG #reg lref) hm =
+    let (| pv, hsl, lb |) = !lref in
     let hsl' = FStar.List.Tot.append hsl [hm] in
     let pv = getLogVersion hsl' in
     let mb = handshakeMessageBytes pv hm in
@@ -94,19 +94,19 @@ let print_log hs_log : Tot bool =
     IO.debug_print_string("LOG : " ^ s ^ "\n")
 
 val getMessages: log -> St hs_log
-let getMessages (LOG #reg lref) = 
+let getMessages (LOG #reg lref) =
     let (| pv, hsl, lb |) = !lref in hsl
 
-val getBytes: log -> St bytes 
-let getBytes (LOG #reg lref) = 
+val getBytes: log -> St bytes
+let getBytes (LOG #reg lref) =
     let (| pv, hsl, lb |) = !lref in lb
 
 val getHash: log -> h:CoreCrypto.hash_alg -> St (b:bytes{length b = CoreCrypto.hashSize h})
-let getHash (LOG #reg lref) h = 
+let getHash (LOG #reg lref) h =
     let (| pv, hsl, lb|) = !lref in
-    let b = 
+    let b =
         if hsl_debug then
-            print_log hsl 
+            print_log hsl
         else false in
     CoreCrypto.hash h lb
 
@@ -133,8 +133,8 @@ let projectLog_CH (l:hs_log{validLog_CH l}) : logInfo_CH =
         PSK.identities = (empty_bytes, empty_bytes);});
     })
 
-val getHash_CH : l:log -> h:CoreCrypto.hash_alg -> 
-  ST (| li:logInfo{is_LogInfo_CH li} & hash:bytes{length hash = CoreCrypto.hashSize h} |)
+val getHash_CH : l:log -> h:CoreCrypto.hash_alg ->
+  ST ( li:logInfo{is_LogInfo_CH li} & hash:bytes{length hash = CoreCrypto.hashSize h} )
     (requires (fun h0 ->
       let lref = l.logref in
       let (| _, hsl, _ |) = sel h0 lref in validLog_CH hsl))
@@ -156,4 +156,4 @@ type validLog_SH (l:hs_log) =
 assume val checkLogSessionHash: hs_log -> csr:csRands -> pv:protocolVersion -> cs:cipherSuite -> negotiatedExtensions -> GTot bool
 assume val checkLogClientFinished: hs_log -> csr:csRands -> pv:protocolVersion -> cs:cipherSuite -> negotiatedExtensions -> GTot bool
 assume val checkLogServerFinished: hs_log -> csr:csRands -> pv:protocolVersion -> cs:cipherSuite -> negotiatedExtensions -> GTot bool
-    
+

--- a/src/tls/KeySchedule.fst
+++ b/src/tls/KeySchedule.fst
@@ -211,10 +211,10 @@ type ks_client_state =
 | C_12_wait_MS: csr:csRands -> alpha:ks_alpha12 -> id:TLSInfo.pmsId -> pms:pms -> ks_client_state
 | C_12_has_MS: csr:csRands -> alpha:ks_alpha12 -> id:TLSInfo.msId -> ms:ms -> ks_client_state
 | C_13_wait_CH: cr:random -> i:esId -> gs:list (namedGroup * CommonDH.key) -> ks_client_state
-| C_13_wait_SH: cr:random -> es:option (| i:esId & es i |) -> cfk0:option (| i:finishedId & fink i |) -> gs:list (namedGroup * CommonDH.key) -> ks_client_state
-| C_13_wait_SF: alpha:ks_alpha13 -> (| i:finishedId & cfk:fink i |) -> (| i:finishedId & sfk:fink i |) -> (| i:asId & ams:ams i |) -> ks_client_state
-| C_13_wait_CF: alpha:ks_alpha13 -> (| i:finishedId & cfk:fink i |) -> (| i:asId & ams:ams i |) -> (| i:rekeyId & rekey_secret i |) -> (| i:finishedId & latecfk:fink i |) -> ks_client_state
-| C_13_postHS: alpha:ks_alpha13 -> (| i:finishedId & fink i |) -> (| i:rekeyId & rekey_secret i |) -> (| i:rmsId & rms i |) -> (| i:exportId & ems i |) -> ks_client_state
+| C_13_wait_SH: cr:random -> es:option ( i:esId & es i ) -> cfk0:option ( i:finishedId & fink i ) -> gs:list (namedGroup * CommonDH.key) -> ks_client_state
+| C_13_wait_SF: alpha:ks_alpha13 -> ( i:finishedId & cfk:fink i ) -> ( i:finishedId & sfk:fink i ) -> ( i:asId & ams:ams i ) -> ks_client_state
+| C_13_wait_CF: alpha:ks_alpha13 -> ( i:finishedId & cfk:fink i ) -> ( i:asId & ams:ams i ) -> ( i:rekeyId & rekey_secret i ) -> ( i:finishedId & latecfk:fink i ) -> ks_client_state
+| C_13_postHS: alpha:ks_alpha13 -> ( i:finishedId & fink i ) -> ( i:rekeyId & rekey_secret i ) -> ( i:rmsId & rms i ) -> ( i:exportId & ems i ) -> ks_client_state
 | C_Done
 
 type ks_server_state =
@@ -222,10 +222,10 @@ type ks_server_state =
 | S_12_wait_CKE_DH: csr:csRands -> alpha:ks_alpha12 -> our_share:CommonDH.key -> ks_server_state
 | S_12_wait_CKE_RSA: csr: csRands -> alpha:ks_alpha12 -> ks_server_state
 | S_12_has_MS: csr:csRands -> alpha:ks_alpha12 -> id:TLSInfo.msId -> ms:ms -> ks_server_state
-| S_13_wait_SH: alpha:ks_alpha13 -> cr:random -> sr:random -> es:option (| i:esId & es i|) -> cfk0:option (| i:finishedId & fink i |) -> hs:(| i:hsId & hs i |) -> ks_server_state
-| S_13_wait_SF: alpha:ks_alpha13 -> (| i:finishedId & cfk:fink i |) -> (| i:finishedId & sfk:fink i |) -> (| i:asId & ams:ams i |) -> ks_server_state
-| S_13_wait_CF: alpha:ks_alpha13 -> (| i:finishedId & cfk:fink i |) -> (| i:asId & ams i |) -> (| i:rekeyId & rekey_secret i |) -> (| i:finishedId & latecfk:fink i |) -> ks_server_state
-| S_13_postHS: alpha:ks_alpha13 -> (| i:finishedId & fink i |) -> (| i:rekeyId & rekey_secret i |) -> (| i:rmsId & rms i |) -> (| i:exportId & ems i |) -> ks_server_state
+| S_13_wait_SH: alpha:ks_alpha13 -> cr:random -> sr:random -> es:option ( i:esId & es i ) -> cfk0:option ( i:finishedId & fink i ) -> hs:( i:hsId & hs i ) -> ks_server_state
+| S_13_wait_SF: alpha:ks_alpha13 -> ( i:finishedId & cfk:fink i ) -> ( i:finishedId & sfk:fink i ) -> ( i:asId & ams:ams i ) -> ks_server_state
+| S_13_wait_CF: alpha:ks_alpha13 -> ( i:finishedId & cfk:fink i ) -> ( i:asId & ams i ) -> ( i:rekeyId & rekey_secret i ) -> ( i:finishedId & latecfk:fink i ) -> ks_server_state
+| S_13_postHS: alpha:ks_alpha13 -> ( i:finishedId & fink i ) -> ( i:rekeyId & rekey_secret i ) -> ( i:rmsId & rms i ) -> ( i:exportId & ems i ) -> ks_server_state
 | S_Done
 
 // Reflecting state separation from HS
@@ -896,7 +896,7 @@ let ks_server_13_sf ks
 
 // Handshake must call this when ClientFinished goes into log
 let ks_client_13_cf ks
-  : ST (| i:exportId & ems i |)
+  : ST ( i:exportId & ems i )
   (requires fun h0 ->
     let kss = sel h0 (KS.state ks) in
     is_C kss /\ is_C_13_wait_CF (C.s kss))

--- a/src/tls/NewHandshake.fsti
+++ b/src/tls/NewHandshake.fsti
@@ -380,7 +380,7 @@ val invalidateSession: s:hs -> ST unit
 (*** Outgoing ***)
 
 // payload of a handshake fragment, to be made opaque eventually
-type message (i:id) = (| rg: frange i & rbytes rg |)
+type message (i:id) = ( rg: frange i & rbytes rg )
 
 // What the HS asks the record layer to do, in that order.
 type outgoing (i:id) (* initial index *) = 

--- a/src/tls/TLS.fst
+++ b/src/tls/TLS.fst
@@ -1059,7 +1059,7 @@ let live_i e r = // is the connection still live?
 
 // let's specify reading d off the input DataStream (incrementing the reader pos)
 
-val sel_reader: h:HST.mem -> connection -> GTot (option (| i:id & StAE.reader i |)) // self-specified
+val sel_reader: h:HST.mem -> connection -> GTot (option ( i:id & StAE.reader i )) // self-specified
 let sel_reader h c =
   let es = epochs c h in
   let j = iT c.hs Reader h in


### PR DESCRIPTION
I am in the process of migrating the fstar parser from fsyacc to menhir, and checked that miTLS still parses correctly. The only "regression" is due to the use of lens parens (| |) to define a dependent pair type which is not a correct usage (as decided after discussion with @nikswamy). This pull-request just replaces these lens parens back to normal parens so that miTLS works fine when the menhir parser will be merged in FStar.