### PR TITLE
Stateless HRR and application extensions

### DIFF
--- a/apps/cmitls/cmitls.c
+++ b/apps/cmitls/cmitls.c
@@ -28,6 +28,7 @@ int option_port;
     STRING_OPTION("-mv", minversion, "sets minimum protocol version to <1.0 | 1.1 | 1.2 | 1.3> (default: 1.2)") \
     BOOL_OPTION("-s", isserver, "run as server instead of client") \
     BOOL_OPTION("-0rtt", 0rtt, "enable early data (server support and client offer)") \
+    BOOL_OPTION("-hrr", hrr, "always send a hello retry as a server") \
     STRING_OPTION("-psk", psk, "L:K add an entry in the PSK database at label L with key K (in hex), associtated with the fist current -cipher") \
     STRING_OPTION("-ticket", ticket, "T:K add ticket T in the PSK database with RMS K (in hex), associated with the first current -cipher") \
     STRING_OPTION("-offerpsk", offerpsk, "offer the given PSK identifier(s) (must be loaded first with --psk). Client only.") \
@@ -159,21 +160,73 @@ void dump(const char *buffer, size_t len)
   }
 }
 
-void* certificate_select(void *cbs, const char *sni, size_t sni_len, const mitls_signature_scheme *sigalgs, size_t sigalgs_len, mitls_signature_scheme *selected)
+const char* pvname(mitls_version pv)
+{
+  switch(pv)
+  {
+    case TLS_SSL3: return "SSL 3.0";
+    case TLS_1p0: return "TLS 1.0";
+    case TLS_1p1: return "TLS 1.1";
+    case TLS_1p2: return "TLS 1.2";
+    case TLS_1p3: return "TLS 1.3";
+  }
+  return "(unknown)";
+}
+
+mitls_nego_action nego_callback(void *cb_state, mitls_version ver,
+  const unsigned char *cexts, size_t cexts_len, mitls_extension **custom_exts,
+  size_t *custom_exts_len, unsigned char **cookie, size_t *cookie_len)
+{
+  printf(" @@@@ Nego callback for %s @@@@\n", pvname(ver));
+  printf("Offered extensions:\n");
+  dump(cexts, cexts_len);
+
+  unsigned char *qtp = NULL;
+  size_t qtp_len;
+  if(FFI_mitls_find_custom_extension(0, cexts, cexts_len, (uint16_t)0x1A, &qtp, &qtp_len))
+  {
+    printf("Transport parameters offered:\n");
+    dump(qtp, qtp_len);
+  }
+
+  *custom_exts = malloc(sizeof(mitls_extension));
+  *custom_exts_len = 1;
+  custom_exts[0]->ext_type = (uint16_t)0x1a;
+  custom_exts[0]->ext_data = "\x00\x01\x02";
+  custom_exts[0]->ext_data_len = 3;
+  printf("Adding server transport parameters:\n");
+  dump(custom_exts[0]->ext_data, custom_exts[0]->ext_data_len);
+
+  if(*cookie != NULL && *cookie_len > 0) {
+    printf("Stateless cookie found, application contents:\n");
+    dump(*cookie, *cookie_len);
+  } else {
+    printf("No application cookie (fist connection).\n");
+    // only used when TLS_nego_retry is returned, but it's safe to set anyway
+    *cookie = "Hello World";
+    *cookie_len = 11;
+    if(option_hrr) return TLS_nego_retry;
+  }
+
+  printf(" @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@\n");
+  return TLS_nego_accept;
+}
+
+void* certificate_select(void *cbs, const unsigned char *sni, size_t sni_len, const mitls_signature_scheme *sigalgs, size_t sigalgs_len, mitls_signature_scheme *selected)
 {
   mipki_state *st = (mipki_state*)cbs;
   mipki_chain r = mipki_select_certificate(st, sni, sni_len, sigalgs, sigalgs_len, selected);
   return (void*)r;
 }
 
-size_t certificate_format(void *cbs, const void *cert_ptr, char *buffer)
+size_t certificate_format(void *cbs, const void *cert_ptr, unsigned char *buffer)
 {
   mipki_state *st = (mipki_state*)cbs;
   mipki_chain chain = (mipki_chain)cert_ptr;
   return mipki_format_chain(st, cert_ptr, buffer, MAX_CHAIN_LEN);
 }
 
-size_t certificate_sign(void *cbs, const void *cert_ptr, const mitls_signature_scheme sigalg, const char *tbs, size_t tbs_len, char *sig)
+size_t certificate_sign(void *cbs, const void *cert_ptr, const mitls_signature_scheme sigalg, const unsigned char *tbs, size_t tbs_len, unsigned char *sig)
 {
   mipki_state *st = (mipki_state*)cbs;
   size_t ret = MAX_SIGNATURE_LEN;
@@ -188,7 +241,7 @@ size_t certificate_sign(void *cbs, const void *cert_ptr, const mitls_signature_s
   return 0;
 }
 
-int certificate_verify(void *cbs, const char* chain_bytes, size_t chain_len, const mitls_signature_scheme sigalg, const char *tbs, size_t tbs_len, char *sig, size_t sig_len)
+int certificate_verify(void *cbs, const unsigned char* chain_bytes, size_t chain_len, const mitls_signature_scheme sigalg, const unsigned char *tbs, size_t tbs_len, const unsigned char *sig, size_t sig_len)
 {
   mipki_state *st = (mipki_state*)cbs;
   mipki_chain chain = mipki_parse_chain(st, chain_bytes, chain_len);
@@ -207,7 +260,7 @@ int certificate_verify(void *cbs, const char* chain_bytes, size_t chain_len, con
   }
 
   size_t slen = sig_len;
-  int r = mipki_sign_verify(st, chain, sigalg, tbs, tbs_len, sig, &slen, MIPKI_VERIFY);
+  int r = mipki_sign_verify(st, chain, sigalg, tbs, tbs_len, (char*)sig, &slen, MIPKI_VERIFY);
   mipki_free_chain(st, chain);
   return r;
 }
@@ -254,15 +307,24 @@ int ConfigureQuic(quic_state **pstate)
         return 4;
     }
 
+    mitls_extension client_qtp[1] = {
+      { // QUIC transport parameters (client)
+        .ext_type = (uint16_t)0x1A,
+        .ext_data = "\xff\xff\x00\x05\x0a\x0b\x0c\x0d\x0e\x00",
+        .ext_data_len = 9
+      }
+    };
+
     memset(&quic_cfg, 0, sizeof(quic_cfg));
     quic_cfg.is_server = (option_isserver) ? 1 : 0;
-    quic_cfg.qp.tp_len = 9;
-    quic_cfg.qp.tp_data = "\xff\xff\x00\x05\x0a\x0b\x0c\x0d\x0e\x00";
     quic_cfg.cipher_suites = option_ciphers;
     quic_cfg.cert_callbacks = &cert_callbacks;
+    quic_cfg.nego_callback = &nego_callback;
     quic_cfg.signature_algorithms = option_sigalgs;
     quic_cfg.named_groups = option_groups;
     quic_cfg.enable_0rtt = (option_0rtt) ? 1 : 0;
+    quic_cfg.exts = client_qtp;
+    quic_cfg.exts_count = 1;
 
     if (option_isserver) {
         quic_cfg.ticket_enc_alg = NULL;
@@ -383,7 +445,7 @@ int Configure(mitls_state **pstate)
 }
 
 // Callback from miTLS, when it is ready to send a message via the socket
-int SendCallback(void *pv, const void *buffer, size_t buffer_size)
+int SendCallback(void *pv, const unsigned char *buffer, size_t buffer_size)
 {
     callback_context *ctx = (callback_context*)pv;
     ssize_t r;
@@ -396,7 +458,7 @@ int SendCallback(void *pv, const void *buffer, size_t buffer_size)
 }
 
 // Callback from miTLS, when it is ready to receive a message via the socket
-int RecvCallback(void* pv, void *buffer, size_t buffer_size)
+int RecvCallback(void* pv, unsigned char *buffer, size_t buffer_size)
 {
     callback_context *ctx = (callback_context*)pv;
     ssize_t r;
@@ -413,7 +475,7 @@ int SingleServer(mitls_state *state, SOCKET clientfd)
 {
     callback_context ctx;
     char *out_msg;
-    void *db;
+    unsigned char *db;
     size_t db_length;
     int r;
     size_t payload_length;

--- a/apps/cmitls/cmitls.c
+++ b/apps/cmitls/cmitls.c
@@ -183,13 +183,13 @@ mitls_nego_action nego_callback(void *cb_state, mitls_version ver,
 
   unsigned char *qtp = NULL;
   size_t qtp_len;
-  if(FFI_mitls_find_custom_extension(0, cexts, cexts_len, (uint16_t)0x1A, &qtp, &qtp_len))
+  if(FFI_mitls_find_custom_extension(option_isserver, cexts, cexts_len, (uint16_t)0x1A, &qtp, &qtp_len))
   {
-    printf("Transport parameters offered:\n");
+    printf("Transport parameters:\n");
     dump(qtp, qtp_len);
   }
 
-  if(option_quic)
+  if(option_quic && option_isserver)
   {
     *custom_exts = malloc(sizeof(mitls_extension));
     *custom_exts_len = 1;

--- a/apps/quicMinusNet/Makefile
+++ b/apps/quicMinusNet/Makefile
@@ -75,4 +75,5 @@ quic.exe: quic.c \
 
 test: quic.exe
 	./quic.exe
-	./quic.exe t
+	./quic.exe 0rtt
+	./quic.exe hrr

--- a/apps/quicMinusNet/quic.c
+++ b/apps/quicMinusNet/quic.c
@@ -59,7 +59,7 @@ mitls_nego_action nego_cb(void *cb_state, mitls_version ver,
 
   unsigned char *qtp = NULL;
   size_t qtp_len;
-  int r = FFI_mitls_find_custom_extension(0, cexts, cexts_len, (uint16_t)0x1A, &qtp, &qtp_len);
+  int r = FFI_mitls_find_custom_extension(1, cexts, cexts_len, (uint16_t)0x1A, &qtp, &qtp_len);
   assert(r && qtp != NULL && qtp_len > 0);
   printf("Transport parameters offered:\n");
   dump(qtp, qtp_len);

--- a/libs/ffi/mitlsffi.h
+++ b/libs/ffi/mitlsffi.h
@@ -205,4 +205,6 @@ extern quic_result MITLS_CALLCONV FFI_mitls_quic_process(/* in */ quic_state *st
 extern int MITLS_CALLCONV FFI_mitls_quic_get_exporter(/* in */ quic_state *state, int early, /* out */ quic_secret *secret);
 extern void MITLS_CALLCONV FFI_mitls_quic_free(/* in */ quic_state *state);
 
+extern int MITLS_CALLCONV FFI_mitls_get_transport_parameters(const char *cexts, size_t cexts_len, char **qtp, size_t *qtp_len);
+
 #endif // HEADER_MITLS_FFI_H

--- a/src/tls/Extensions.fst
+++ b/src/tls/Extensions.fst
@@ -832,7 +832,7 @@ let rec extensionPayloadBytes = function
     | _                             -> vlbytes 2 (pskBytes psk))
   | E_early_data edi                -> vlbytes 2 (earlyDataIndicationBytes edi)
   | E_supported_versions vs         -> vlbytes 2 (protocol_versions_bytes vs)
-  | E_cookie c                      -> (lemma_repr_bytes_values (length c); vlbytes 2 (vlbytes 2 c))
+  | E_cookie c                      -> (lemma_repr_bytes_values (length c); vlbytes 2 c)
   | E_psk_key_exchange_modes kex    -> vlbytes 2 (client_psk_kexes_bytes kex)
   | E_extended_ms                   -> vlbytes 2 empty_bytes
   | E_ec_point_format l             -> vlbytes 2 (ecpfListBytes l)
@@ -1205,9 +1205,7 @@ let parseExtension mt b =
 
     | (0x00z, 0x2cz) -> // cookie
       if length data <= 2 || length data >= 65538 then error "cookie" else
-      (match vlparse 2 data with
-      | Error z -> Error z
-      | Correct data -> Correct (E_cookie data, None))
+      Correct (E_cookie data, None)
 
     | (0x00z, 0x2dz) -> // key ex
       if length data < 2 then error "psk_key_exchange_modes" else

--- a/src/tls/FFI.fst
+++ b/src/tls/FFI.fst
@@ -354,6 +354,14 @@ let ffiSetEarlyData cfg x =
   max_early_data = if x = 0ul then None else Some x;
   }
 
+val ffiAddCustomExtension: cfg:config -> UInt16.t -> bytes -> ML config
+let ffiAddCustomExtension cfg h b =
+  trace ("offering custom extension "^(hex_of_bytes (bytes_of_uint16 h)));
+  trace ("extension contents: "^(hex_of_bytes b));
+  { cfg with
+  custom_extensions = (h, b) :: cfg.custom_extensions
+  }
+
 val ffiSetTicketKey: a:string -> k:bytes -> ML bool
 let ffiSetTicketKey a k =
   (match findsetting a aeads with
@@ -423,9 +431,9 @@ let ffiSetTicketCallback (cfg:config) (ctx:FStar.Dyn.dyn) (cb:ticket_cb_fun) =
   trace "Setting a new ticket callback.";
   {cfg with ticket_callback = {ticket_context = ctx; new_ticket = cb}}
 
-let ffiSetNegoCallback (cfg:config) (ctx:FStar.Dyn.dyn) (cb:server_nego_cb_fun) =
+let ffiSetNegoCallback (cfg:config) (ctx:FStar.Dyn.dyn) (cb:nego_cb_fun) =
   trace "Setting a new server negotiation callback.";
-  {cfg with nego_callback = {server_nego_context = ctx; server_nego = cb}}
+  {cfg with nego_callback = {nego_context = ctx; negotiate = cb}}
 
 let ffiSetCertCallbacks (cfg:config) (cb:cert_cb) =
   trace "Setting up certificate callbacks.";

--- a/src/tls/Handshake.fst
+++ b/src/tls/Handshake.fst
@@ -102,6 +102,8 @@ let version_of (s:hs) = Nego.version s.nego
 let resumeInfo_of (s:hs) = Nego.resume s.nego
 let get_mode (s:hs) = Nego.getMode s.nego
 let is_server_hrr (s:hs) = Nego.is_server_hrr s.nego
+let is_0rtt_offered (s:hs) =
+  let mode = get_mode s in Nego.zeroRTToffer mode.Nego.n_offer
 let epochs_of (s:hs) = s.epochs
 
 (* WIP on the handshake invariant
@@ -1165,7 +1167,7 @@ let recv_ccs (hs:hs) =
     trace "recv_ccs";
     // Draft 22 CCS during HRR
     // Because of stateless HRR, this may also happen as the very first message before CH (!!!)
-    if Nego.is_hrr hs.nego || !hs.state = S_Idle then
+    if Nego.is_hrr hs.nego || S_Idle? !hs.state then
      begin
       trace "IGNORING CCS (workaround for implementations that send CCS after HRR)";
       InAck false false

--- a/src/tls/Handshake.fst
+++ b/src/tls/Handshake.fst
@@ -1164,7 +1164,8 @@ let rec recv_fragment (hs:hs) #i rg f =
 let recv_ccs (hs:hs) =
     trace "recv_ccs";
     // Draft 22 CCS during HRR
-    if Nego.is_hrr hs.nego then
+    // Because of stateless HRR, this may also happen as the very first message before CH (!!!)
+    if Nego.is_hrr hs.nego || !hs.state = S_Idle then
      begin
       trace "IGNORING CCS (workaround for implementations that send CCS after HRR)";
       InAck false false

--- a/src/tls/Handshake.fsti
+++ b/src/tls/Handshake.fsti
@@ -29,6 +29,9 @@ val get_mode: hs -> ST Negotiation.mode
 val is_server_hrr: hs -> ST bool
   (requires fun h0 -> True)
   (ensures fun h0 _ h1 -> h0 == h1)
+val is_0rtt_offered: hs -> ST bool
+  (requires fun h0 -> True)
+  (ensures fun h0 _ h1 -> h0 == h1)
 
 // annoyingly, we will need specification-level variants too.
 

--- a/src/tls/HandshakeLog.fst
+++ b/src/tls/HandshakeLog.fst
@@ -288,6 +288,13 @@ let getHash #ha (LOG #reg st) =
     Hashing.finalize #ha cst.hash
 *)
 
+let load_stateless_cookie l hrr digest =
+  let st = !l in
+  let fake_ch = (bytes_of_hex "fe0000") @| (vlbytes 1 digest) in
+  let h = OpenHash (fake_ch @| (helloRetryRequestBytes hrr)) in
+  l := State st.transcript st.outgoing st.outgoing_next_keys st.outgoing_complete
+             st.incoming st.parsed h st.pv st.kex st.dh_group
+
 (* SEND *)
 let send l m =
   trace ("emit "^HandshakeMessages.string_of_handshakeMessage m);

--- a/src/tls/HandshakeLog.fst
+++ b/src/tls/HandshakeLog.fst
@@ -288,10 +288,17 @@ let getHash #ha (LOG #reg st) =
     Hashing.finalize #ha cst.hash
 *)
 
+// Must be called after receiving a CH in the Init state of nego, indicating
+// that the retry is stateless.
 let load_stateless_cookie l hrr digest =
   let st = !l in
+  // The cookie is loaded after CH2 is written to the hash buffer
+  let OpenHash ch2b = st.hashes in
   let fake_ch = (bytes_of_hex "fe0000") @| (vlbytes 1 digest) in
-  let h = OpenHash (fake_ch @| (helloRetryRequestBytes hrr)) in
+  trace ("Installing prefix to transcript: "^(hex_of_bytes fake_ch));
+  let hrb = helloRetryRequestBytes hrr in
+  trace ("HRR bytes: "^(hex_of_bytes hrb));
+  let h = OpenHash (fake_ch @| hrb @| ch2b) in
   l := State st.transcript st.outgoing st.outgoing_next_keys st.outgoing_complete
              st.incoming st.parsed h st.pv st.kex st.dh_group
 
@@ -494,9 +501,10 @@ let rec hashHandshakeMessages t p hs n nb =
         let hs = match m with
           | HelloRetryRequest hrr ->
             let ha = verifyDataHashAlg_of_ciphersuite hrr.hrr_cipher_suite in
-            let hht = bytes_of_hex "fe0000" in // message_type
             let hmsg = Hashing.compute ha b in
-            let hht = hht @| (bytes_of_int 1 (length hmsg)) @| hmsg in
+            let hht = (bytes_of_hex "fe0000") @| (vlbytes 1 hmsg) in
+            trace ("Replacing CH1 in transcript with "^(hex_of_bytes hht));
+            trace ("HRR bytes: "^(hex_of_bytes mb));
             OpenHash (hht @| mb)
           | _ -> OpenHash (b @| mb)
         in

--- a/src/tls/HandshakeLog.fsti
+++ b/src/tls/HandshakeLog.fsti
@@ -185,6 +185,10 @@ let write_transcript h0 h1 (s:log) (m:msg) =
     hashAlg h1 s == hashAlg h0 s /\
     transcript h1 s == transcript h0 s @ [m]
 
+val load_stateless_cookie: s:log -> h:hrr -> digest:bytes -> ST unit
+  (requires (fun h0 -> writing h0 s /\ valid_transcript (transcript h0 s)))
+  (ensures (fun h0 _ h1 -> modifies_one s h0 h1 /\ writing h1 s))
+
 val send: s:log -> m:msg -> ST unit
   (requires (fun h0 ->
     writing h0 s /\

--- a/src/tls/HandshakeMessages.fst
+++ b/src/tls/HandshakeMessages.fst
@@ -1511,8 +1511,8 @@ let sessionTicketBytes t =
 val sessionTicketBytes13: sticket13 -> Tot (b:bytes{hs_msg_bytes HT_session_ticket b})
 let sessionTicketBytes13 t =
   let payload =
-    bytes_of_int 4 (UInt32.v t.ticket13_lifetime) @|
-    bytes_of_int 4 (UInt32.v t.ticket13_age_add) @|
+    bytes_of_int32 t.ticket13_lifetime @|
+    bytes_of_int32 t.ticket13_age_add @|
     vlbytes 1 t.ticket13_nonce @|
     vlbytes 2 t.ticket13_ticket @|
     extensionsBytes t.ticket13_extensions in

--- a/src/tls/HandshakeMessages.fst
+++ b/src/tls/HandshakeMessages.fst
@@ -49,7 +49,7 @@ type handshakeType =
   | HT_server_hello
   | HT_session_ticket
   | HT_end_of_early_data
-  | HT_hello_retry_request
+//  | HT_hello_retry_request
   | HT_encrypted_extensions
   | HT_certificate
   | HT_server_key_exchange
@@ -72,7 +72,7 @@ let htBytes t =
   | HT_server_hello         -> 2z
   | HT_session_ticket       -> 4z
   | HT_end_of_early_data -> 5z
-  | HT_hello_retry_request  -> 6z
+//  | HT_hello_retry_request  -> 6z
   | HT_encrypted_extensions -> 8z
   | HT_certificate          -> 11z
   | HT_server_key_exchange  -> 12z
@@ -99,7 +99,7 @@ let parseHt b =
   |  2z -> Correct HT_server_hello
   |  4z -> Correct HT_session_ticket
   |  5z -> Correct HT_end_of_early_data
-  |  6z -> Correct HT_hello_retry_request
+//  |  6z -> Correct HT_hello_retry_request
   |  8z -> Correct HT_encrypted_extensions
   | 11z -> Correct HT_certificate
   | 12z -> Correct HT_server_key_exchange
@@ -1597,7 +1597,7 @@ let parseSessionTicket13 b =
 
 
 (* Hello retry request *)
-val helloRetryRequestBytes: hrr -> Tot (b:bytes{hs_msg_bytes HT_hello_retry_request b})
+val helloRetryRequestBytes: hrr -> Tot (b:bytes{hs_msg_bytes HT_server_hello b})
 let helloRetryRequestBytes hrr =
   serverHelloBytes ({
     sh_protocol_version = TLS_1p2;
@@ -1650,7 +1650,18 @@ let helloRetryRequestBytes_is_injective h1 h2 = admit()
 
 (* TODO: inversion lemmas *)
 val parseHelloRetryRequest: bytes -> Tot (result hrr)
-let parseHelloRetryRequest b = Error (AD_decode_error, perror __SOURCE_FILE__ __LINE__ "HRR message type is disabled since draft 22")
+let parseHelloRetryRequest b =
+  match parseServerHello b with
+  | Correct sh ->
+    if sh.sh_server_random = bytes_of_hex "cf21ad74e59a6111be1d8c021e65b891c2a211167abb8c5e079e09e2c8a8339c" then
+      Correct ({
+        hrr_sessionID = sh.sh_sessionID;
+        hrr_cipher_suite = sh.sh_cipher_suite;
+        hrr_extensions = Some?.v (sh.sh_extensions)
+      })
+    else error "not a proper HRR (magic nonce does not match)"
+  | Error z -> Error z
+
 (*
   if length b >= 4 then
     let pv, cs, data = split2 b 2 2 in
@@ -1887,7 +1898,7 @@ let handshakeMessageBytes_is_injective pv msg1 msg2 =
     | HT_certificate_request -> certificateRequestBytes_is_injective (CertificateRequest?._0 msg1) (CertificateRequest?._0 msg2)
     | HT_certificate_verify -> certificateVerifyBytes_is_injective (CertificateVerify?._0 msg1) (CertificateVerify?._0 msg2)
     | HT_hello_request -> ()
-    | HT_hello_retry_request -> helloRetryRequestBytes_is_injective (HelloRetryRequest?._0 msg1) (HelloRetryRequest?._0 msg2)
+    //| HT_hello_retry_request -> helloRetryRequestBytes_is_injective (HelloRetryRequest?._0 msg1) (HelloRetryRequest?._0 msg2)
     (* | HT_server_configuration -> serverConfigurationBytes_is_injective (ServerConfiguration?._0 msg1) (ServerConfiguration?._0 msg2) *)
     //| HT_next_protocol -> nextProtocolBytes_is_injective (NextProtocol?._0 msg1) (NextProtocol?._0 msg2)
   )
@@ -2079,7 +2090,7 @@ let parseHandshakeMessage pv kex hstype body =
     | HT_session_ticket, Some TLS_1p3,_ -> mapResult NewSessionTicket13 (parseSessionTicket13 body)
     | HT_session_ticket, Some _,_       -> mapResult NewSessionTicket (parseSessionTicket body)
     | HT_end_of_early_data, Some TLS_1p3,_ -> parseEmptyMessage EndOfEarlyData body
-    | HT_hello_retry_request,_,_        -> mapResult HelloRetryRequest (parseHelloRetryRequest body)
+//    | HT_hello_retry_request,_,_        -> mapResult HelloRetryRequest (parseHelloRetryRequest body)
     | HT_encrypted_extensions,_,_       -> mapResult EncryptedExtensions (parseEncryptedExtensions body)
     | HT_certificate, Some TLS_1p3,_    -> mapResult Certificate13 (parseCertificate13 body)
     | HT_certificate, Some _,_          -> mapResult Certificate (parseCertificate body)

--- a/src/tls/KeySchedule.fst
+++ b/src/tls/KeySchedule.fst
@@ -463,7 +463,7 @@ let ks_server_13_init ks cr cs pskid g_gx =
       dbg ("Using negotiated PSK identity: "^(print_bytes id));
       let i, psk, h : esId * bytes * Hashing.Spec.alg =
         match Ticket.check_ticket id with
-        | Some (Ticket.Ticket13 cs li rmsId rms) ->
+        | Some (Ticket.Ticket13 cs li rmsId rms _ _) ->
           dbg ("Ticket RMS: "^(print_bytes rms));
           let i = ResumptionPSK #li rmsId in
           let CipherSuite13 _ h = cs in

--- a/src/tls/Negotiation.fst
+++ b/src/tls/Negotiation.fst
@@ -1268,7 +1268,8 @@ let computeServerMode cfg co serverRandom =
           TLSConstants.filter_aux cfg.signature_algorithms TLSConstants.mem_rev sigalgs
         in
         if sigalgs = [] then None
-        else cert_select_cb cfg (get_sni co) sigalgs
+        // FIXME(adl) workaround for a bug in TLSConstants that causes signature schemes list to be parsed in reverse order
+        else cert_select_cb cfg (get_sni co) (List.Tot.rev sigalgs)
       in
     match compute_cs13 cfg co pske shares (Some? scert) with
     | Error z -> Error z

--- a/src/tls/Negotiation.fst
+++ b/src/tls/Negotiation.fst
@@ -182,10 +182,17 @@ let find_signature_algorithms_cert o : option signatureSchemeList =
   | None -> None
   | Some (Extensions.E_signature_algorithms_cert algs) -> Some algs
 
+(*
 let find_quic_parameters o: option TLSConstants.quicParameters =
   match find_client_extension Extensions.E_quic_parameters? o with
   | Some (Extensions.E_quic_parameters qp) -> Some qp
   | _ -> None
+
+let find_server_quic_parameters m =
+  match find_server_extension Extensions.E_quic_parameters? m with
+  | Some (Extensions.E_quic_parameters qp) -> Some qp
+  | _ -> None
+*)
 
 let find_cookie o =
   match find_client_extension Extensions.E_cookie? o with
@@ -319,11 +326,6 @@ let find_server_extension filter m =
   match m.n_server_extensions with
   | None -> None
   | Some es -> List.Tot.find filter es
-
-let find_server_quic_parameters m =
-  match find_server_extension Extensions.E_quic_parameters? m with
-  | Some (Extensions.E_quic_parameters qp) -> Some qp
-  | _ -> None
 
 let is_resumption12 m =
   not (is_pv_13 m.n_protocol_version)  &&

--- a/src/tls/Negotiation.fst
+++ b/src/tls/Negotiation.fst
@@ -439,10 +439,12 @@ let computeOffer r cfg resume nonce ks pskinfo =
     match pskinfo with
     | (_, i) :: _ -> i.allow_early_data // Must be the first PSK
     | _ -> false in
+  (* Moved to application callback
   let qp =
     match cfg.quic_parameters with
     | Some (qv::_, qp) -> Some (QuicParametersClient qv qp)
     | _ -> None in
+  *)
   let extensions =
     Extensions.prepareExtensions
       cfg.min_version
@@ -450,7 +452,7 @@ let computeOffer r cfg resume nonce ks pskinfo =
       cfg.cipher_suites
       cfg.peer_name
       cfg.alpn
-      qp
+      // qp
       cfg.extended_master_secret
       cfg.safe_renegotiation
       (compatible_psk && Some? cfg.max_early_data)
@@ -706,14 +708,14 @@ let client_HelloRetryRequest #region (ns:t region Client) hrr (s:option share) =
     let ext' = TLSConstants.choose_aux s choose_extension (Some?.v offer.ch_extensions) in
 
     // Echo the cookie for QUIC stateless retry
-    let ext' = match List.Tot.find Extensions.E_cookie? el with
-      | Some cookie -> cookie :: ext'
-      | None -> ext' in
+    let ext', no_cookie = match List.Tot.find Extensions.E_cookie? el with
+      | Some cookie -> cookie :: ext', false
+      | None -> ext', true in
 
     if sid <> offer.ch_sessionID then
       Error(AD_illegal_parameter, "mismatched session ID in HelloRetryRequest")
-    else if None? (group_of_hrr hrr) && None? ns.cfg.quic_parameters then
-      Error(AD_illegal_parameter, "only keyShare-based HRR is supported on client")
+    else if None? (group_of_hrr hrr) && no_cookie then
+      Error(AD_illegal_parameter, "received a HRR that would yield the same ClientHello")
     else
      begin
       let offer' = {offer with ch_extensions = Some ext'} in
@@ -1226,10 +1228,15 @@ let rec register_shares (l:list pre_share)
   | [] -> []
   | (| g, gx |) :: t -> (| g, CommonDH.register #g gx |) :: (register_shares t)
 
+// For application-handled extensions set by nego callback,
+// such as QUIC transport parameters
+type extra_ext = // list (e:Extensions.extension{E_unknown_extension? e})
+  list Extensions.extension
+
 //17-03-30 still missing a few for servers.
 type serverMode =
   | ServerHelloRetryRequest: hrr -> serverMode
-  | ServerMode: mode -> certNego -> serverMode
+  | ServerMode: mode -> certNego -> extra_ext -> serverMode
 
 let get_sni (o:offer) : bytes =
   match find_client_extension Extensions.E_server_name? o with
@@ -1271,7 +1278,6 @@ let computeServerMode cfg co serverRandom =
         hrr_extensions = [
           Extensions.E_supported_versions (Extensions.ServerPV TLS_1p3);
           Extensions.E_key_share (CommonDH.HRRKeyShare ng);
-          Extensions.E_cookie (CoreCrypto.random 32)
         ]; } in
       Correct(ServerHelloRetryRequest hrr)
     | Correct ((PSK_EDH j ogx cs)::_, _) ->
@@ -1289,7 +1295,7 @@ let computeServerMode cfg co serverRandom =
         None // TODO: n_client_cert_request
         None
         ogx)
-      None)) // No cert
+      None [])) // No cert
     | Correct ((JUST_EDH gx cs) :: _, _) ->
       (trace "Negotiated Pure EDH key exchange";
       let Some (cert, sa) = scert in
@@ -1310,7 +1316,7 @@ let computeServerMode cfg co serverRandom =
           None // TODO: n_client_cert_request
           (Some (Cert.chain_up schain, sa))
           (Some gx))
-        scert))
+        scert []))
     end
   | Correct pv ->
     let valid_ticket =
@@ -1335,7 +1341,7 @@ let computeServerMode cfg co serverRandom =
         None
         None
         None
-        None) None)
+        None) None [])
     | _ ->
       // Make sure NullCompression is offered
       if not (List.Tot.mem NullCompression co.ch_compressions)
@@ -1368,7 +1374,7 @@ let computeServerMode cfg co serverRandom =
                 None
                 (Some (Cert.chain_up schain, sa))
                 None) // no client key share yet for 1.2
-              (Some(cert, sa))
+              (Some(cert, sa)) []
             ))
 
 private
@@ -1400,9 +1406,9 @@ let aux_extension_ok (o1, hrr) (e:Extensions.extension) =
             //(extensionBytes e) = (extensionBytes e'))
 
 val server_ClientHello: #region:rgn -> t region Server ->
-  HandshakeMessages.ch ->
+  HandshakeMessages.ch -> log:HandshakeLog.t ->
   St (result serverMode)
-let server_ClientHello #region ns offer =
+let server_ClientHello #region ns offer log =
   trace ("offered client extensions "^string_of_option_extensions offer.ch_extensions);
   trace ("offered cipher suites "^(string_of_ciphersuites offer.ch_cipher_suites));
   trace (match (offered_versions TLS_1p0 offer) with
@@ -1428,47 +1434,93 @@ let server_ClientHello #region ns offer =
         Error z
       | Correct (ServerHelloRetryRequest hrr) ->
         Error(AD_illegal_parameter, "client sent the same hello in response to hello retry")
-      | Correct(ServerMode m cert) ->
+      | Correct (ServerMode m cert _) ->
         trace ("negotiated after HRR "^string_of_pv m.n_protocol_version^" "^string_of_ciphersuite m.n_cipher_suite);
-        HST.op_Colon_Equals ns.state (S_ClientHello m cert);
-        sm
+        let nego_cb = ns.cfg.nego_callback in
+        let unk_ext = (* List.Tot.filter Extensions.E_unknown_extension? *) o2.ch_extensions in
+        let ext_bytes = HandshakeMessages.optionExtensionsBytes unk_ext in
+        match nego_cb.server_nego nego_cb.server_nego_context m.n_protocol_version ext_bytes (Some empty_bytes) with
+        | Nego_accept sexts ->
+          (match Extensions.parseOptExtensions Extensions.EM_ServerHello sexts with
+          | Error z -> Error (AD_internal_error, "server negotiation callback returned ill-formatted extra extensions")
+          | Correct (el, _) ->
+            let el = match el with | None -> [] | Some l -> l in
+            HST.op_Colon_Equals ns.state (S_ClientHello m cert);
+            Correct (ServerMode m cert el))
+        | _ ->
+          trace ("Application requested to abort the handshake after internal HRR.");
+          Error (AD_handshake_failure, "application aborted the handshake by callback")
     else
       Error(AD_illegal_parameter, "Inconsistant parameters between first and second client hello")
   | S_Init _ ->
     let sm = computeServerMode ns.cfg offer ns.nonce in
+    let previous_cookie = // for stateless HRR
+      match find_cookie offer with
+      | None -> None
+      | Some c ->
+        match Ticket.check_cookie c with
+        | None -> trace ("WARNING: ignorning invalid cookie "^(hex_of_bytes c)); None
+        | Some (hrr, digest, extra) ->
+          trace ("Loading cookie "^(hex_of_bytes c));
+          let hrr = { hrr with hrr_extensions =
+            (Extensions.E_cookie c) :: hrr.hrr_extensions; } in
+          // Overwrite the current transcript digest with values from cookie
+          HandshakeLog.load_stateless_cookie log hrr digest;
+          Some extra // for the server nego callback
+      in
     match sm with
     | Error z ->
       trace ("negotiation failed: "^string_of_error z);
       Error z
     | Correct (ServerHelloRetryRequest hrr) ->
+      // Internal HRR caused by group negotiation
+      // We do not invoke the server nego callback in this case
       // record the initial offer and return the HRR to HS
+      let ha = verifyDataHashAlg_of_ciphersuite hrr.hrr_cipher_suite in
+      let digest = HandshakeLog.hash_tag #ha log in
+      let cookie = Ticket.create_cookie hrr digest empty_bytes in
+      let hrr = { hrr with hrr_extensions =
+        (Extensions.E_cookie cookie) :: hrr.hrr_extensions; } in
       HST.op_Colon_Equals ns.state (S_HRR offer hrr);
       sm
-    | Correct (ServerMode m cert) ->
-      // Forcing HRR for source address validation
-      if ns.cfg.offer_shares = [] then
+    | Correct (ServerMode m cert _) ->
+      let nego_cb = ns.cfg.nego_callback in
+      let unk_ext = (* List.Tot.filter Extensions.E_unknown_extension? *) offer.ch_extensions in
+      let ext_bytes = HandshakeMessages.optionExtensionsBytes unk_ext in
+      match nego_cb.server_nego nego_cb.server_nego_context m.n_protocol_version ext_bytes previous_cookie with
+      | Nego_abort ->
+        trace ("Application requested to abort the handshake.");
+        Error (AD_handshake_failure, "application aborted the handshake by callback")
+      | Nego_retry cextra ->
         let hrr = ({
           hrr_sessionID = offer.ch_sessionID;
           hrr_cipher_suite = m.n_cipher_suite;
           hrr_extensions = [
             Extensions.E_supported_versions (Extensions.ServerPV TLS_1p3);
-            Extensions.E_cookie (CoreCrypto.random 32)
           ]}) in
+        let ha = verifyDataHashAlg_of_ciphersuite hrr.hrr_cipher_suite in
+        let digest = HandshakeLog.hash_tag #ha log in
+        let cookie = Ticket.create_cookie hrr digest cextra in
+        let hrr = { hrr with hrr_extensions =
+          (Extensions.E_cookie cookie) :: hrr.hrr_extensions; } in
         ns.state := (S_HRR offer hrr);
         Correct (ServerHelloRetryRequest hrr)
-      else
-       begin
+      | Nego_accept sext ->
         trace ("negotiated "^string_of_pv m.n_protocol_version^" "^string_of_ciphersuite m.n_cipher_suite);
-        ns.state := (S_ClientHello m cert);
-        sm
-       end
+        match Extensions.parseOptExtensions Extensions.EM_ServerHello sext with
+        | Error z -> Error (AD_internal_error, "server negotiation callback returned ill-formatted extra extensions")
+        | Correct (el, _) ->
+          let el = match el with | None -> [] | Some l -> l in
+          ns.state := S_ClientHello m cert;
+          Correct (ServerMode m cert el)
 
 let share_of_serverKeyShare (ks:CommonDH.serverKeyShare) : share =
   let CommonDH.Share g gy = ks in (| g, gy |)
 
-val server_ServerShare: #region:rgn -> t region Server -> option CommonDH.serverKeyShare  ->
+val server_ServerShare: #region:rgn -> t region Server ->
+  option CommonDH.serverKeyShare -> extra_ext ->
   St (result mode)
-let server_ServerShare #region ns ks =
+let server_ServerShare #region ns ks app_exts =
   match HST.op_Bang ns.state with
   | S_ClientHello mode cert ->
     let cexts = mode.n_offer.ch_extensions in
@@ -1488,6 +1540,12 @@ let server_ServerShare #region ns ks =
     | Correct sexts ->
       begin
       trace ("including server extensions (SH + EE) " ^ string_of_option_extensions sexts);
+      let sexts = match sexts with
+        | Some el ->
+          trace ("extra extensions from application callback: "^string_of_extensions app_exts);
+          Some (el @ app_exts)
+        | _ -> sexts
+        in
       let mode = Mode
         mode.n_offer
         mode.n_hrr

--- a/src/tls/QUIC.fst
+++ b/src/tls/QUIC.fst
@@ -177,14 +177,17 @@ val ffiAcceptConnected:
   config:config -> ML Connection.connection
 let ffiAcceptConnected ctx snd rcv config = accept ctx snd rcv config
 
-
 /// new QUIC-specific properties
-///
+private let qp_filter (e:Extensions.extension) =
+  match e with
+  | Extensions.E_unknown_extension (hd, _) -> uint16_of_bytes hd = 0x1Aus
+  | _ -> false
+
 let get_transport_parameters (b:bytes) : ML (option bytes) =
   match Extensions.parseOptExtensions Extensions.EM_ClientHello b with
   | Correct (Some el, _) ->
-    (match List.Tot.find Extensions.E_quic_parameters? el with
-    | Some (Extensions.E_quic_parameters b) -> Some b
+    (match List.Tot.find qp_filter el with
+    | Some (Extensions.E_unknown_extension (_, b)) -> Some b
     | _ -> None)
   | Error _ -> trace ("Warning: bad extension list passed to get_transport_parameters"); None
 

--- a/src/tls/QUIC.fst
+++ b/src/tls/QUIC.fst
@@ -140,7 +140,6 @@ let rec recv c =
 let quic_check config =
   if config.min_version <> TLS_1p3 then trace "WARNING: not TLS 1.3";
   if not config.non_blocking_read then trace "WARNING: reads are blocking";
-  if None? config.quic_parameters then trace "WARNING: missing parameters";
   if None? config.alpn            then trace "WARNING: missing ALPN"
 
 /// New client and server connections (without any  I/O yet)
@@ -209,18 +208,11 @@ private let quicVersion (n:UInt32.t) = QuicCustomVersion n // avoid overflow in 
 //    | 1 -> QuicVersion1
 //    | _ -> QuicCustomVersion n
 
-let ffiConfig (qp: bytes) (versions: list UInt32.t) (host:bytes) =
-  let ver = List.Tot.map quicVersion versions in
+let ffiConfig (host:bytes) =
   let h = if length host = 0 then None else Some host in
-  let qpl =
-    match Extensions.parseQuicParameters_aux qp with
-    | Error z -> failwith "Invalid QUIC transport parameters"
-    | Correct qpl -> qpl
-    in
   { defaultConfig with
     min_version = TLS_1p3;
     max_version = TLS_1p3;
     peer_name = h;
-    non_blocking_read = true;
-    quic_parameters = Some (ver, qpl)
+    non_blocking_read = true
   }

--- a/src/tls/QUIC.fst
+++ b/src/tls/QUIC.fst
@@ -177,20 +177,6 @@ val ffiAcceptConnected:
   config:config -> ML Connection.connection
 let ffiAcceptConnected ctx snd rcv config = accept ctx snd rcv config
 
-/// new QUIC-specific properties
-private let qp_filter (e:Extensions.extension) =
-  match e with
-  | Extensions.E_unknown_extension (hd, _) -> uint16_of_bytes hd = 0x1Aus
-  | _ -> false
-
-let get_transport_parameters (b:bytes) : ML (option bytes) =
-  match Extensions.parseOptExtensions Extensions.EM_ClientHello b with
-  | Correct (Some el, _) ->
-    (match List.Tot.find qp_filter el with
-    | Some (Extensions.E_unknown_extension (_, b)) -> Some b
-    | _ -> None)
-  | Error _ -> trace ("Warning: bad extension list passed to get_transport_parameters"); None
-
 let ffiConfig (host:bytes) =
   let h = if length host = 0 then None else Some host in
   { defaultConfig with

--- a/src/tls/TLS.fst
+++ b/src/tls/TLS.fst
@@ -1080,7 +1080,7 @@ let rec readFragment c i =
       match StAE.decrypt (reader_epoch e) (ct,payload) with
       | None ->
         trace "StAE decrypt failed.";
-        if StAE.tolerate_decrypt_failure #i rd then
+        if Handshake.is_0rtt_offered c.hs && StAE.tolerate_decrypt_failure #i rd then
          begin
           trace "Ignoring the decryption failure (rejected 0-RTT data)";
           readFragment c i

--- a/src/tls/TLSConstants.fst
+++ b/src/tls/TLSConstants.fst
@@ -1823,7 +1823,8 @@ let string_of_quicParameters = function
 
 type pskInfo = {
   ticket_nonce: option bytes;
-  time_created: int;
+  time_created: UInt32.t;
+  ticket_age_add: UInt32.t;
   allow_early_data: bool;      // New draft 13 flag
   allow_dhe_resumption: bool;  // New draft 13 flag
   allow_psk_resumption: bool;  // New draft 13 flag

--- a/src/tls/TLSConstants.fst
+++ b/src/tls/TLSConstants.fst
@@ -1595,6 +1595,7 @@ let signatureSchemeList =
 
 (** Serializing function for a SignatureScheme list *)
 
+// FIXME(adl) this is serializing in reverse order (shb @| b)
 let rec signatureSchemeListBytes_aux
   (algs: signatureSchemeList)
   (b:bytes)
@@ -1651,6 +1652,7 @@ let signatureSchemeListBytes_is_injective
   signatureSchemeListBytes_aux_is_injective algs1 empty_bytes algs1 algs2 empty_bytes algs2
 
 (** Parsing function for a SignatureScheme list *)
+// FIXME(adl) this is parsing in reverse order (sha::algs)
 val parseSignatureSchemeList: pinverse_t signatureSchemeListBytes
    let rec parseSignatureSchemeList_aux: b:bytes -> algs:list signatureScheme -> b':bytes{length b' + op_Multiply 2 (List.Tot.length algs) == length b} ->
     Tot

--- a/src/tls/TLSConstants.fst
+++ b/src/tls/TLSConstants.fst
@@ -1747,6 +1747,7 @@ request_client_certificate: single_assign ServerCertificateRequest // uses this 
 type alpn_entry = b:bytes{0 < length b /\ length b < 256}
 type alpn = l:list alpn_entry{List.Tot.length l < 256}
 
+(* TRANSPORT PARAMETERS ARE NOW MANAGED BY APPLICATION
 type quicParameter =
   | Quic_initial_max_stream_data of UInt32.t
   | Quic_initial_max_data of UInt32.t
@@ -1816,6 +1817,7 @@ let string_of_quicParameters = function
     string_of_quicParameters_aux_fold "versions: " string_of_quicVersion " " v ^ "\n" ^
     string_of_quicParameters_aux_fold "" string_of_quicParameter "\n" p
   | None -> "(none)"
+*)
 
 type pskInfo = {
   ticket_nonce: option bytes;

--- a/src/tls/TLSInfo.fst
+++ b/src/tls/TLSInfo.fst
@@ -81,13 +81,13 @@ let defaultTicketCB = {
   new_ticket = defaultTicketCBFun;
 }
 
-val defaultServerNegoCBFun: server_nego_cb_fun
+val defaultServerNegoCBFun: nego_cb_fun
 let defaultServerNegoCBFun _ pv cext ocookie =
-  Nego_accept empty_bytes
+  Nego_accept []
 
-let defaultServerNegoCB : server_nego_cb = {
-  server_nego_context = FStar.Dyn.mkdyn ();
-  server_nego = defaultServerNegoCBFun;
+let defaultServerNegoCB : nego_cb = {
+  nego_context = FStar.Dyn.mkdyn ();
+  negotiate = defaultServerNegoCBFun;
 }
 
 let none4 = fun _ _ _ _ -> None
@@ -121,6 +121,7 @@ let defaultConfig =
   // Client
   hello_retry = true;
   offer_shares = [SEC CC.ECC_X25519];
+  custom_extensions = [];
 
   // Server
   check_client_version_in_pms_for_old_tls = true;

--- a/src/tls/TLSInfo.fst
+++ b/src/tls/TLSInfo.fst
@@ -81,6 +81,15 @@ let defaultTicketCB = {
   new_ticket = defaultTicketCBFun;
 }
 
+val defaultServerNegoCBFun: server_nego_cb_fun
+let defaultServerNegoCBFun _ pv cext ocookie =
+  Nego_accept empty_bytes
+
+let defaultServerNegoCB : server_nego_cb = {
+  server_nego_context = FStar.Dyn.mkdyn ();
+  server_nego = defaultServerNegoCBFun;
+}
+
 let none4 = fun _ _ _ _ -> None
 let empty3 = fun _ _ _ -> []
 let none5 = fun _ _ _ _ _ -> None
@@ -105,7 +114,6 @@ let defaultConfig =
   {
   min_version = TLS_1p2;
   max_version = TLS_1p3;
-  quic_parameters = None;
   cipher_suites = cipherSuites_of_nameList default_cipherSuites;
   named_groups = default_groups;
   signature_algorithms = default_signature_schemes;
@@ -126,6 +134,7 @@ let defaultConfig =
   enable_tickets = true;
 
   ticket_callback = defaultTicketCB;
+  nego_callback = defaultServerNegoCB;
   cert_callbacks = defaultCertCB;
 
   alpn = None;

--- a/src/tls/Test.Handshake.fst
+++ b/src/tls/Test.Handshake.fst
@@ -108,35 +108,6 @@ let main cafile cert key () = // could try with different client and server conf
   PKI.free pki;
   if !ok then C.EXIT_SUCCESS else C.EXIT_FAILURE
 
-
-(* now using Test.StAE code for those:
-
-private let pre_id (role:role) =
-  let cr  = createBytes 32 0z in
-  let sr  = createBytes 32 0z in
-  let kdf = PRF_TLS_1p2 kdf_label (HMAC Hashing.Spec.SHA256) in
-  let g = CommonDH.ECDH CoreCrypto.ECC_P256 in
-  let gx  = CommonDH.keygen g in
-  let gy, gxy = CommonDH.dh_responder #g gx in
-  let pms = PMS.DHPMS g (CommonDH.pubshare gx) gy (PMS.ConcreteDHPMS gxy) in
-  let msid = StandardMS pms (cr @| sr) kdf in
-  ID12 TLS_1p2 msid kdf (AEAD CoreCrypto.AES_128_GCM Hashing.Spec.SHA256) cr sr role
-
-private val encryptRecord :
-  #id:StAE.stae_id -> wr:StAE.writer id -> ct:Content.contentType -> plain:bytes -> ML bytes
-private let encryptRecord (#id:StAE.stae_id) (wr:StAE.writer id) ct plain : ML bytes =
-  let rg: Range.frange id = (0, length plain) in
-  let f: DataStream.fragment id rg = plain in
-  let f: Content.fragment id = Content.mk_fragment id ct rg f in
-  StAE.encrypt #id wr f
-
-private val decryptRecord : #id:StAE.stae_id -> rd:StAE.reader id -> ct:Content.contentType -> cipher:bytes -> ML bytes
-private let decryptRecord (#id:StAE.stae_id) (rd:StAE.reader id) ct cipher : ML bytes =
-  let ctxt: Content.decrypted id = (ct, cipher) in
-  let Some d = StAE.decrypt #id rd ctxt in
-  Content.repr id d
-*)
-
 (* 18-01-24 most of the test predates the handshake rewriting...
 
 private let sendRecordE encrypted tcp pv ct msg =

--- a/src/tls/Test.StAE.fst
+++ b/src/tls/Test.StAE.fst
@@ -1,7 +1,7 @@
-module Test.StAE 
+module Test.StAE
 // adapted from test/TestGCM
 
-open FStar.Bytes // for @| 
+open FStar.Bytes // for @|
 open FStar.Error
 open FStar.Printf
 open TLSError
@@ -9,11 +9,11 @@ open TLSConstants
 open TLSInfo
 open Range
 
-module StAE = StAE 
+module StAE = StAE
 module Range = Range
 module DH = CommonDH
 
-open FStar.HyperStack 
+open FStar.HyperStack
 open FStar.HyperStack.ST
 (*
 open FStar.Heap
@@ -33,7 +33,7 @@ open StAE
 *)
 
 let prefix = "Test.StAE"
-let ok: ref bool = ralloc root true 
+let ok: ref bool = ralloc root true
 
 val discard: bool -> ST unit
   (requires (fun _ -> True))
@@ -51,28 +51,24 @@ private let pre_id (role:role) =
   let cr  = Bytes.create 32ul 0z in
   let sr  = Bytes.create 32ul 0z in
   let kdf = PRF_TLS_1p2 kdf_label (HMac Hashing.Spec.SHA256) in
-  let Some g = DH.group_of_namedGroup (SEC CoreCrypto.ECC_P256) in
-  let gx  = DH.keygen g in
-  let gy, gxy = DH.dh_responder #g (DH.pubshare gx) in
-  let pms = PMS.DHPMS g (DH.pubshare gx) gy (PMS.ConcreteDHPMS gxy) in
-  let msid = StandardMS pms (cr @| sr) kdf in
+  let msid = StandardMS PMS.DummyPMS (cr @| sr) kdf in
   ID12 TLS_1p2 msid kdf (AEAD CoreCrypto.AES_256_GCM Hashing.Spec.SHA256) cr sr role
 
 let id12 = pre_id Client
 
 #set-options "--lax"
 
-let id13 = 
+let id13 =
   let cr  = Bytes.create 32ul 0z in
-  let ch0 = { 
-    li_ch0_cr = cr; 
-    li_ch0_ed_psk = Bytes.utf8_encode "whatever"; 
+  let ch0 = {
+    li_ch0_cr = cr;
+    li_ch0_ed_psk = Bytes.utf8_encode "whatever";
     li_ch0_ed_ae = CoreCrypto.AES_256_GCM;
     li_ch0_ed_hash = Hashing.Spec.SHA256; } in
   let li = LogInfo_CH0 ch0 in
-  let i = ExpandedSecret 
-      (EarlySecretID (NoPSK Hashing.Spec.SHA256)) 
-      ClientEarlyTrafficSecret 
+  let i = ExpandedSecret
+      (EarlySecretID (NoPSK Hashing.Spec.SHA256))
+      ClientEarlyTrafficSecret
       (Bytes.utf8_encode "whatever") in
   let kid: keyId = KeyID #li i in
   ID13 kid
@@ -92,19 +88,19 @@ let decryptRecord (#id:StAE.stae_id) (rd:StAE.reader id) ct cipher : St (option 
 
 
 val test: id:StAE.stae_id -> St unit
-let test id = 
-  let text0 = Bytes.utf8_encode "attack at" in 
+let test id =
+  let text0 = Bytes.utf8_encode "attack at" in
   let text1 = Bytes.utf8_encode "dawn" in
   // For TLS 1.2, key materials consist of an AES256 key plus 4 bytes of IV salt.
-  let key = 
-    if ID13? id then 
+  let key =
+    if ID13? id then
     bytes_of_hex (
     "feffe9928665731c6d6a8f9467308308feffe9928665731c6d6a8f9467308308"^
-    "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef") 
+    "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef")
     else
     bytes_of_hex (
     "feffe9928665731c6d6a8f9467308308feffe9928665731c6d6a8f9467308308"^
-    "01020304") 
+    "01020304")
     in
   let wr = StAE.coerce root id key in
   let rd = StAE.genReader root #id wr in
@@ -113,44 +109,44 @@ let test id =
   let c1 = encryptRecord #id wr Content.Application_data text1 in
   nprint (sprintf "c1 size=%ul data=%s" (Bytes.len c1) (Bytes.hex_of_bytes c1));
   nprint "start";
-  let c = Bytes.utf8_encode "we need a long-enough ciphertext (static pre)" in 
+  let c = Bytes.utf8_encode "we need a long-enough ciphertext (static pre)" in
   let d = decryptRecord #id rd Content.Application_data c in
 
-  if None? d   
+  if None? d
   then nprint "decryption fails on wrong cipher"
   else eprint "decryption should fail";
-  
-  let d = decryptRecord #id rd Content.Application_data c1 in
-  if None? d   
-  then nprint "decryption fails on wrong sequence number"
-  else eprint "decryption should fail on wrong sequence number"; 
 
-  if id = id13 then 
+  let d = decryptRecord #id rd Content.Application_data c1 in
+  if None? d
+  then nprint "decryption fails on wrong sequence number"
+  else eprint "decryption should fail on wrong sequence number";
+
+  if id = id13 then
     nprint "TLS 1.3 does not intend to provide outer CT authentication"
-  else ( 
+  else (
     let d = decryptRecord #id rd Content.Alert c0 in
-    if None? d 
+    if None? d
     then nprint "decryption fails on wrong CT"
     else eprint "decryption should fail on wrong CT" );
 
-  let d = decryptRecord #id rd Content.Application_data c0 in 
-  ( match d with 
+  let d = decryptRecord #id rd Content.Application_data c0 in
+  ( match d with
     | Some v ->
-      if v = text0 
+      if v = text0
       then nprint "first decryption succeeds"
       else eprint "wrong decrypted message"
     | _ -> eprint "first decryption failed" );
 
-  let d = decryptRecord #id rd Content.Application_data c1 in 
-  ( match d with 
+  let d = decryptRecord #id rd Content.Application_data c1 in
+  ( match d with
     | Some v ->
-      if v = text1 
+      if v = text1
       then nprint "second decryption succeeds"
       else eprint "wrong decrypted message"
     | _ -> eprint "second decryption failed" )
 
 // Called from Test.Main
-let main () = 
+let main () =
   test id12;
-  test id13 ; 
-  if !ok then C.EXIT_SUCCESS else C.EXIT_FAILURE 
+  test id13 ;
+  if !ok then C.EXIT_SUCCESS else C.EXIT_FAILURE

--- a/src/tls/Ticket.fst
+++ b/src/tls/Ticket.fst
@@ -94,8 +94,8 @@ type ticket =
 // Currently we use dummy indexes until we can serialize them properly
 let dummy_rmsid ae h =
   let li = {
-    li_sh_cr = CC.random 32;
-    li_sh_sr = CC.random 32;
+    li_sh_cr = Bytes.create 32ul 0z;
+    li_sh_sr = Bytes.create 32ul 0z;
     li_sh_ae = ae;
     li_sh_hash = h;
     li_sh_psk = None;
@@ -110,7 +110,7 @@ let dummy_rmsid ae h =
 
 // Dummy msId TODO serialize and encrypt them properly
 let dummy_msId pv cs ems =
-  StandardMS PMS.DummyPMS (CC.random 64) (kefAlg pv cs ems)
+  StandardMS PMS.DummyPMS (Bytes.create 64ul 0z) (kefAlg pv cs ems)
 
 let parse (b:bytes) =
   trace ("Parsing ticket "^(hex_of_bytes b));

--- a/src/tls/Ticket.fst
+++ b/src/tls/Ticket.fst
@@ -48,7 +48,7 @@ private let dummy_id (a:aeadAlg) : St AE.id =
   assume false;
   let h = Hashing.Spec.SHA256 in
   let li = LogInfo_CH0 ({
-    li_ch0_cr = CC.zero 32;
+    li_ch0_cr = CC.random 32;
     li_ch0_ed_psk = empty_bytes;
     li_ch0_ed_ae = a;
     li_ch0_ed_hash = h;
@@ -59,8 +59,8 @@ private let dummy_id (a:aeadAlg) : St AE.id =
 private let ticket_enc : reference ticket_key
   =
   let id0 = dummy_id CC.CHACHA20_POLY1305 in
-  let salt : AE.salt id0 = CC.zero (AE.iv_length id0) in
-  let key : AE.key id0 = CC.zero (AE.key_length id0) in
+  let salt : AE.salt id0 = CC.random (AE.iv_length id0) in
+  let key : AE.key id0 = CC.random (AE.key_length id0) in
   let wr = AE.coerce id0 region key salt in
   let rd = AE.genReader region #id0 wr in
   ralloc region (Key id0 wr rd)

--- a/src/tls/extract/cstubs/core_crypto.c
+++ b/src/tls/extract/cstubs/core_crypto.c
@@ -32,6 +32,14 @@
     return _x;                                                                 \
   }
 
+// For ticket age, currently using C runtime <time.h> with second resolution
+// FIXME(adl) switch to milisecond timers, after we check the Windows options
+#include <time.h>
+uint32_t CoreCrypto_now()
+{
+  return (uint32_t)time(NULL);
+}
+
 #ifndef NO_OPENSSL
 
 #include <openssl/bn.h>
@@ -47,7 +55,6 @@
 #include <openssl/pem.h>
 #include <openssl/rand.h>
 #include <openssl/rsa.h>
-
 
 FStar_Bytes_bytes CoreCrypto_dh_agreement(CoreCrypto_dh_key x0,
                                           FStar_Bytes_bytes x1) {
@@ -538,7 +545,7 @@ static BCRYPT_ALG_HANDLE g_hAlgRandom;
 int CoreCrypto_Initialize(void)
 {
 
-  NTSTATUS st = BCryptOpenAlgorithmProvider(&g_hAlgRandom, BCRYPT_RNG_ALGORITHM, NULL, 
+  NTSTATUS st = BCryptOpenAlgorithmProvider(&g_hAlgRandom, BCRYPT_RNG_ALGORITHM, NULL,
 #ifdef _KERNEL_MODE
                     BCRYPT_PROV_DISPATCH
 #else
@@ -548,7 +555,7 @@ int CoreCrypto_Initialize(void)
   if (!NT_SUCCESS(st)) {
     KRML_HOST_EPRINTF("BCryptOpenAlgorithmProvider failed: 0x%x\n", (unsigned int)st);
     return 0;
-  }    
+  }
   return 1;
 }
 

--- a/src/tls/extract/cstubs/core_crypto.c
+++ b/src/tls/extract/cstubs/core_crypto.c
@@ -34,10 +34,9 @@
 
 // For ticket age, currently using C runtime <time.h> with second resolution
 // FIXME(adl) switch to milisecond timers, after we check the Windows options
-#include <time.h>
 uint32_t CoreCrypto_now()
 {
-  return (uint32_t)time(NULL);
+  return (uint32_t)KRML_HOST_TIME();
 }
 
 #ifndef NO_OPENSSL

--- a/src/tls/extract/cstubs/mitlsffi.c
+++ b/src/tls/extract/cstubs/mitlsffi.c
@@ -354,6 +354,7 @@ static TLSConstants_nego_action nego_cb_proxy(FStar_Dyn_dyn cbs, TLSConstants_pr
   if(cookie.tag == FStar_Pervasives_Native_Some)
   {
     app_cookie = (unsigned char *)cookie.v.data;
+    if(app_cookie == NULL) app_cookie = (unsigned char*)""; // None vs Some empty_bytes / NULL
     app_cookie_len = cookie.v.length;
   }
 
@@ -390,7 +391,7 @@ static TLSConstants_nego_action nego_cb_proxy(FStar_Dyn_dyn cbs, TLSConstants_pr
   return a;
 }
 
-int MITLS_CALLCONV FFI_mitls_configure_server_nego_callback(mitls_state *state, void *cb_state, pfn_FFI_nego_cb nego_cb)
+int MITLS_CALLCONV FFI_mitls_configure_nego_callback(mitls_state *state, void *cb_state, pfn_FFI_nego_cb nego_cb)
 {
   ENTER_HEAP_REGION(state->rgn);
   wrapped_nego_cb *cbs = KRML_HOST_MALLOC(sizeof(wrapped_nego_cb));

--- a/src/tls/extract/cstubs/mitlsffi.c
+++ b/src/tls/extract/cstubs/mitlsffi.c
@@ -271,10 +271,10 @@ int MITLS_CALLCONV FFI_mitls_configure_alpn(/* in */ mitls_state *state, const c
     return 1;
 }
 
-int MITLS_CALLCONV FFI_mitls_configure_custom_extensions(/* in */ mitls_state *state, const mitls_extension *exts, size_t exts_len)
+int MITLS_CALLCONV FFI_mitls_configure_custom_extensions(/* in */ mitls_state *state, const mitls_extension *exts, size_t exts_count)
 {
   ENTER_HEAP_REGION(state->rgn);
-  for(size_t i = 0; i < exts_len; i++)
+  for(size_t i = 0; i < exts_count; i++)
   {
     char *c = KRML_HOST_MALLOC(exts->ext_data_len);
     memcpy(c, exts->ext_data, exts->ext_data_len);

--- a/src/tls/extract/mlstubs/FFIRegister.ml
+++ b/src/tls/extract/mlstubs/FFIRegister.ml
@@ -17,7 +17,6 @@ let _ = Callback.register "MITLS_FFI_Config" FFI.ffiConfig;
         Callback.register "MITLS_FFI_QuicCreateClient" QUIC.ffiConnect;
         Callback.register "MITLS_FFI_QuicCreateServer" QUIC.ffiAcceptConnected;
         Callback.register "MITLS_FFI_QuicProcess" QUIC.recv;
-        Callback.register "MITLS_FFI_QuicGetPeerParameters" QUIC.get_peer_parameters;
         (* Callback.register "MITLS_FFI_TicketCallback" FFI.ffiTicketCallback;
         Callback.register "MITLS_FFI_CertSelectCallback" FFI.ffiCertSelectCallback;
         Callback.register "MITLS_FFI_CertFormatCallback" FFI.ffiCertFormatCallback;


### PR DESCRIPTION
- [x] Implement the stateless mode of HRR
- [x] allow servers to ask for HRR from callback
- [x] Implement an API to let applications negotiate custom extensions
- [x] Add a stateless HRR handshake mode to quicMinusNet, destroying the server state between the two CH
- [x] Fix the OCaml FFI
- [x] Fix cmitls
- [ ] Adapt other QUIC implementations built on mitlsffi.h