### PR TITLE
Fixes for link issues on Linux in the quic2 branch

### DIFF
--- a/apps/cmitls/Makefile
+++ b/apps/cmitls/Makefile
@@ -5,9 +5,6 @@ MLCRYPTO_HOME ?= ../../../MLCrypto
 UNAME=$(shell uname)
 MARCH?=x86_64
 
-nullstring := #empty variable
-space := $(nullstring) $(nullstring) #one space
-
 ifeq ($(OS),Windows_NT)
   LIBMITLS=libmitls.dll
   LIBPKI=libmipki.dll

--- a/apps/cmitls/Makefile
+++ b/apps/cmitls/Makefile
@@ -2,10 +2,11 @@ MITLS_HOME ?= ../..
 FSTAR_HOME ?= ../../../FStar
 MLCRYPTO_HOME ?= ../../../MLCrypto
 
-include $(FSTAR_HOME)/ulib/ml/Makefile.include
-
 UNAME=$(shell uname)
 MARCH?=x86_64
+
+nullstring := #empty variable
+space := $(nullstring) $(nullstring) #one space
 
 ifeq ($(OS),Windows_NT)
   LIBMITLS=libmitls.dll
@@ -18,21 +19,24 @@ ifeq ($(OS),Windows_NT)
 	  MITLS_HOME := $(shell cygpath -u ${MITLS_HOME})
 	  MLCRYPTO_HOME := $(shell cygpath -u ${MLCRYPTO_HOME})
 	endif
-  PATH := $(MITLS_HOME)/src/pki:$(MITLS_HOME)/src/tls/extract/Kremlin-Library:$(MLCRYPTO_HOME)/openssl:$(PATH)
+  LIBPATHS=$(MITLS_HOME)/src/pki:$(MITLS_HOME)/src/tls/extract/Kremlin-Library:$(MLCRYPTO_HOME)/openssl
+  PATH := $(LIBPATHS):$(PATH)
   export PATH
 else ifeq ($(UNAME),Darwin)
   LIBMITLS=libmitls.so
   LIBPKI=libmipki.so
   PIC=-fPIC
   WINSOCK=
-  DYLD_LIBRARY_PATH := $(MITLS_HOME)/src/pki:$(MITLS_HOME)/src/tls/extract/Kremlin-Library:$(DYLD_LIBRARY_PATH)
+  LIBPATHS=$(MITLS_HOME)/src/pki:$(MITLS_HOME)/src/tls/extract/Kremlin-Library
+  DYLD_LIBRARY_PATH := $(LIBPATHS):$(DYLD_LIBRARY_PATH)
   export DYLD_LIBRARY_PATH
 else ifeq ($(UNAME),Linux)
   LIBMITLS=libmitls.so
   LIBPKI=libmipki.so
   PIC=-fPIC -lpthread
   WINSOCK=
-  LD_LIBRARY_PATH := $(MITLS_HOME)/src/pki:$(MITLS_HOME)/src/tls/extract/Kremlin-Library:$(MLCRYPTO_HOME)/openssl:$(LD_LIBRARY_PATH)
+  LIBPATHS=$(MITLS_HOME)/src/pki:$(MITLS_HOME)/src/tls/extract/Kremlin-Library:$(MLCRYPTO_HOME)/openssl
+  LD_LIBRARY_PATH := $(LIBPATHS):$(LD_LIBRARY_PATH)
   export LD_LIBRARY_PATH
 endif
 
@@ -47,25 +51,14 @@ $(MITLS_HOME)/src/pki/$(LIBPKI):
 $(MITLS_HOME)/src/tls/extract/Kremlin-Library/$(LIBMITLS):
 	$(MAKE) -j8 -C ../../src/tls -f Makefile.Kremlin build-library
 
-copy: $(LIBMITLS) $(LIBPKI)
-
-$(LIBMITLS): $(MITLS_HOME)/src/tls/extract/Kremlin-Library/$(LIBMITLS)
-	cp $(MITLS_HOME)/src/tls/extract/Kremlin-Library/$(LIBMITLS) .
-
-$(LIBPKI): $(MITLS_HOME)/src/pki/$(LIBPKI)
-	cp $(MITLS_HOME)/src/pki/$(LIBPKI) .
-	cp $(MLCRYPTO_HOME)/openssl/$(OPENSSL) .
-
-cmitls.exe: cmitls.c \
+cmitls.exe: cmitls.c ../../libs/ffi/mitlsffi.h ../../src/pki/mipki.h \
 	$(MITLS_HOME)/src/pki/$(LIBPKI) \
 	$(MITLS_HOME)/src/tls/extract/Kremlin-Library/$(LIBMITLS)
 	$(CC) $(CFLAGS) -I../../src/pki -I../../libs/ffi \
 	  -I$(MITLS_HOME)/src/tls/extract/Kremlin-Library/stub \
 	  -I$(MITLS_HOME)/src/tls/extract/Kremlin-Library/include \
-	  -L$(MITLS_HOME)/src/pki \
-	  -L$(MITLS_HOME)/src/tls/extract/Kremlin-Library \
-	  -L$(MLCRYPTO_HOME)/openssl \
-	  -Wall -lmitls -lmipki $(PIC) cmitls.c -o cmitls.exe $(WINSOCK)
+	  -L$(subst :, -L,$(LIBPATHS)) \
+	  -Wall cmitls.c -lmitls -lmipki $(PIC) -o cmitls.exe $(WINSOCK)
 
 test: cmitls.exe
 	./cmitls.exe google.com 443

--- a/apps/quicMinusNet/Makefile
+++ b/apps/quicMinusNet/Makefile
@@ -19,20 +19,23 @@ ifeq ($(OS),Windows_NT)
     HACL_HOME := $(shell cygpath -u ${HACL_HOME})
     MLCRYPTO_HOME := $(shell cygpath -u ${MLCRYPTO_HOME})
   endif
-  PATH := $(MITLS_HOME)/src/pki:$(MITLS_HOME)/src/tls/extract/Kremlin-Library:$(HACL_HOME)/secure_api/out/runtime_switch:$(MLCRYPTO_HOME)/openssl:$(PATH)
+  LIBPATHS=$(MITLS_HOME)/src/pki:$(MITLS_HOME)/src/tls/extract/Kremlin-Library:$(HACL_HOME)/secure_api/out/runtime_switch:$(MLCRYPTO_HOME)/openssl
+  PATH := $(LIBPATHS):$(PATH)
   export PATH
 else ifeq ($(UNAME),Darwin)
   LIBMITLS=libmitls.so
   LIBQC=libquicprovider.so
   LIBPKI=libmipki.so
-  DYLD_LIBRARY_PATH := $(MITLS_HOME)/src/pki:$(MITLS_HOME)/src/tls/extract/Kremlin-Library:$(HACL_HOME)/secure_api/out/runtime_switch:$(DYLD_LIBRARY_PATH)
+  LIBPATHS=$(MITLS_HOME)/src/pki:$(MITLS_HOME)/src/tls/extract/Kremlin-Library:$(HACL_HOME)/secure_api/out/runtime_switch
+  DYLD_LIBRARY_PATH := $(LIBPATHS):$(DYLD_LIBRARY_PATH)
   export DYLD_LIBRARY_PATH
 else ifeq ($(UNAME),Linux)
   LIBMITLS=libmitls.so
   LIBQC=libquicprovider.so
   LIBPKI=libmipki.so
   CFLAGS+=-lpthread
-  LD_LIBRARY_PATH := $(MITLS_HOME)/src/pki:$(MITLS_HOME)/src/tls/extract/Kremlin-Library:$(HACL_HOME)/secure_api/out/runtime_switch:$(MLCRYPTO_HOME)/openssl:$(LD_LIBRARY_PATH)
+  LIBPATHS=$(MITLS_HOME)/src/pki:$(MITLS_HOME)/src/tls/extract/Kremlin-Library:$(HACL_HOME)/secure_api/out/runtime_switch:$(MLCRYPTO_HOME)/openssl
+  LD_LIBRARY_PATH := $(LIBPATHS):$(LD_LIBRARY_PATH)
   export LD_LIBRARY_PATH
 endif
 
@@ -50,30 +53,19 @@ $(MITLS_HOME)/src/tls/extract/Kremlin-Library/$(LIBMITLS):
 $(HACL_HOME)/secure_api/out/runtime_switch/$(LIBQC):
 	$(MAKE) -j8 -C $(HACL_HOME)/secure_api
 
-copy: $(LIBMITLS) $(LIBPKI) $(LIBQC)
-
-$(LIBMITLS): $(MITLS_HOME)/src/tls/extract/Kremlin-Library/$(LIBMITLS)
-	cp $(MITLS_HOME)/src/tls/extract/Kremlin-Library/$(LIBMITLS) .
-
-$(LIBPKI): $(MITLS_HOME)/src/pki/$(LIBPKI)
-	cp $(MITLS_HOME)/src/pki/$(LIBPKI) .
-	cp $(MLCRYPTO_HOME)/openssl/$(OPENSSL) .
-
-$(LIBQC): $(HACL_HOME)/secure_api/out/runtime_switch/$(LIBQC)
-	cp $(HACL_HOME)/secure_api/out/runtime_switch/$(LIBQC) .
-
 quic.exe: quic.c \
+	$(MITLS_HOME)/src/pki/mipki.h \
+	$(HACL_HOME)/secure_api/QuicProvider/quic_provider.h \
+	../../libs/ffi/mitlsffi.h \
 	$(MITLS_HOME)/src/pki/$(LIBPKI) \
 	$(HACL_HOME)/secure_api/out/runtime_switch/$(LIBQC) \
 	$(MITLS_HOME)/src/tls/extract/Kremlin-Library/$(LIBMITLS)
 	$(CC) -fPIC -I$(MITLS_HOME)/src/tls/extract/Kremlin-Library/include \
 	  -I$(MITLS_HOME)/src/tls/extract/Kremlin-Library/stub -I../../src/pki \
 	  -I../../libs/ffi -I$(HACL_HOME)/secure_api/QuicProvider \
-	  -L$(MITLS_HOME)/src/pki \
-	  -L$(MITLS_HOME)/src/tls/extract/Kremlin-Library \
-	  -L$(HACL_HOME)/secure_api/out/runtime_switch \
-	  -L$(MLCRYPTO_HOME)/openssl \
-	  -lmitls -lquicprovider -lmipki quic.c $(CFLAGS) -o quic.exe
+	  quic.c \
+          -L$(subst :, -L,$(LIBPATHS)) \
+	  $(CFLAGS) -lmitls -lquicprovider -lmipki -o quic.exe
 
 test: quic.exe
 	./quic.exe

--- a/src/pki/Makefile
+++ b/src/pki/Makefile
@@ -105,7 +105,7 @@ libmipki.dll: libcrypto.a mipki.o
 	$(CC) $(COPTS) -shared mipki.o libcrypto.a -lws2_32 -o $@
 
 libmipki.so: libcrypto.a mipki.o
-	$(CC) $(COPTS) -shared mipki.o libcrypto.a -o $@
+	$(CC) $(COPTS) -shared mipki.o libcrypto.a -lpthread -ldl -Wl,-z,defs -o $@
 
 else # NO_OPENSSL
 
@@ -113,7 +113,7 @@ libmipki.dll: mipki.o
 	$(CC) $(COPTS) -DNO_OPENSSL -shared mipki.o -lws2_32 -o $@
 
 libmipki.so: mipki.o
-	$(CC) $(COPTS) -DNO_OPENSSL -shared mipki.o -o $@
+	$(CC) $(COPTS) -DNO_OPENSSL -shared mipki.o -lpthread -ldl -Wl,-z,defs -o $@
 
 endif
 

--- a/src/pki/Makefile
+++ b/src/pki/Makefile
@@ -28,6 +28,7 @@ ifeq ($(OS),Windows_NT)
     ARCH = win32
     EXTRA_OPTS =
     EXTRA_LIBS = -L.
+    SO_OPTS =
     CC = $(MARCH)-w64-mingw32-gcc
     ifeq ($(MARCH),x86_64)
       LIB_MACHINE=x64
@@ -47,11 +48,13 @@ else
     ifeq ($(UNAME_S),Darwin)
         EXTRA_OPTS =
         EXTRA_LIBS = -L.
+        SO_OPTS =
         ARCH = osx
         OPENSSL_CONF = ./config enable-tls1_3
     else
         EXTRA_OPTS = -fPIC
         EXTRA_LIBS = -L.
+        SO_OPTS = -Wl,-z,defs 
         ARCH = x86_64
         OPENSSL_CONF = ./config enable-tls1_3 -fPIC
     endif
@@ -105,7 +108,7 @@ libmipki.dll: libcrypto.a mipki.o
 	$(CC) $(COPTS) -shared mipki.o libcrypto.a -lws2_32 -o $@
 
 libmipki.so: libcrypto.a mipki.o
-	$(CC) $(COPTS) -shared mipki.o libcrypto.a -lpthread -ldl -Wl,-z,defs -o $@
+	$(CC) $(COPTS) -shared mipki.o libcrypto.a -lpthread -ldl $(SO_OPTS) -o $@
 
 else # NO_OPENSSL
 
@@ -113,7 +116,7 @@ libmipki.dll: mipki.o
 	$(CC) $(COPTS) -DNO_OPENSSL -shared mipki.o -lws2_32 -o $@
 
 libmipki.so: mipki.o
-	$(CC) $(COPTS) -DNO_OPENSSL -shared mipki.o -lpthread -ldl -Wl,-z,defs -o $@
+	$(CC) $(COPTS) -DNO_OPENSSL -shared mipki.o -lpthread -ldl $(SO_OPTS) -o $@
 
 endif
 

--- a/src/tls/extract/Kremlin-Library/Makefile
+++ b/src/tls/extract/Kremlin-Library/Makefile
@@ -22,7 +22,7 @@ else ifeq ($(UNAME),Linux)
   VARIANT = -Linux
   CFLAGS := -fPIC $(CFLAGS)
   LD_LIBRARY_PATH :=  $(MITLS_HOME)/src/pki:$(LD_LIBRARY_PATH)
-  LDOPTS := -lpthread -Xlinker -z -Xlinker noexecstack -Xlinker --version-script -Xlinker $(MITLS_HOME)/src/tls/libmitls_version_script $(LDOPTS)
+  LDOPTS := -lpthread -Xlinker -z -Xlinker noexecstack -Xlinker --version-script -Xlinker $(MITLS_HOME)/src/tls/libmitls_version_script -Wl,-z,defs $(LDOPTS)
   SO = so
   export LD_LIBRARY_PATH
 endif
@@ -92,7 +92,7 @@ all: libmitls.$(SO)
 -include $(addsuffix .d,$(FILES))
 
 libmitls.$(SO): $(addsuffix .o,$(FILES)) vale/sha256-$(MARCH)$(VARIANT).o vale/aes-$(MARCH)$(VARIANT).o
-	$(CC) $^ -shared -o $@ -Wl,-z,defs $(LDOPTS)
+	$(CC) $^ -shared -o $@ $(LDOPTS)
 
 clean:
 	rm -fr $(addsuffix .o,$(FILES)) $(addsuffix .c,$(FILES)) libmitls.$(SO)

--- a/src/tls/extract/Kremlin-Library/Makefile
+++ b/src/tls/extract/Kremlin-Library/Makefile
@@ -92,7 +92,7 @@ all: libmitls.$(SO)
 -include $(addsuffix .d,$(FILES))
 
 libmitls.$(SO): $(addsuffix .o,$(FILES)) vale/sha256-$(MARCH)$(VARIANT).o vale/aes-$(MARCH)$(VARIANT).o
-	$(CC) $^ -shared -o $@ $(LDOPTS)
+	$(CC) $^ -shared -o $@ -Wl,-z,defs $(LDOPTS)
 
 clean:
 	rm -fr $(addsuffix .o,$(FILES)) $(addsuffix .c,$(FILES)) libmitls.$(SO)


### PR DESCRIPTION
I hit a number of issues linking and using .so files on Bash for Windows running Ubuntu.

- libmipki.so was linked without -lcrypto, leaving it with unresolved symbols.  That meant that every app that linked against libmipki.so also had to link in our build of OpenSSL libcrypto*.so.

- libmipki.so was linked without -lpthread, again, leaving it with unresolved symbols.  However, just passing -lpthread when building cmitls.exe didn't work... got a mysterious error about pthread_at_fork being hidden.  Turns out libmpki.so and cmitls.exe cannot both share the same binding to libpthread.so.  Same fix as libcrypto*.so... link libmipki.so against libpthread.so.

- pass -Wl,-z,defs to catch accidental missing symbols in the future

- tidy up how the test apps were build and run, so they can directly reference .so files in-place, without needing to copy them, both for linking and to run.

I confirmed that these changes still work on Cygwin.

EDIT:  Sigh.  No, the mingw linker doesn't like the -z switch after all.  I missed the error when I built on Cygwin.  Will refactor it out into a !Cygwin path.

EDIT: Neither Cygwin nor OS/X versions of ld support -z, so I made the change Linux-specific.