### PR TITLE
Build and test libquiccrypto.dll with MSVC

### DIFF
--- a/src/windows/quiccrypto/CommonInclude.h
+++ b/src/windows/quiccrypto/CommonInclude.h
@@ -22,12 +22,12 @@
 #endif
 __declspec(noreturn) extern void KremlExit(int n);
 
-extern void* KrmlHostMalloc(size_t cb);
-extern void* KrmlHostCalloc(size_t n, size_t cb);
-extern void KrmlHostFree(void *pv);
-#define KRML_HOST_MALLOC KrmlHostMalloc
-#define KRML_HOST_CALLOC KrmlHostCalloc
-#define KRML_HOST_FREE   KrmlHostFree
+//extern void* KrmlHostMalloc(size_t cb);
+//extern void* KrmlHostCalloc(size_t n, size_t cb);
+//extern void KrmlHostFree(void *pv);
+//#define KRML_HOST_MALLOC KrmlHostMalloc
+//#define KRML_HOST_CALLOC KrmlHostCalloc
+//#define KRML_HOST_FREE   KrmlHostFree
 
 #define KRML_HOST_PRINTF DbgPrint
 #define KRML_HOST_EPRINTF DbgPrint

--- a/src/windows/quiccrypto/makefile.vs
+++ b/src/windows/quiccrypto/makefile.vs
@@ -1,6 +1,6 @@
 CCOPTS = /nologo /O2 /Gy /GF /Gw /GA /MD /Zi -I. -I.. -FI.\CommonInclude.h /DNO_OPENSSL
 
-all: libquiccrypto_code.lib
+all: libquiccrypto.dll test
 
 # 'dir /b *.c' then replace "^(.*)" by "  \1 \\"
 SOURCES = \
@@ -31,6 +31,12 @@ libquiccrypto_code.lib: $(SOURCES:.c=.obj) $(PLATFORM_OBJS)
   
 libquiccrypto.dll: libquiccrypto_code.lib libquiccrypto.def dllmain.obj
   link /nologo /dll /debug:full /out:libquiccrypto.dll libquiccrypto_code.lib dllmain.obj /def:libquiccrypto.def /OPT:ICF /OPT:REF ntdll.lib
+
+test.exe: test.obj libquiccrypto.dll
+  link /nologo /ltcg /debug:full /out:test.exe test.obj libquiccrypto.lib
+
+test: test.exe libquiccrypto.dll
+  test.exe
   
 .c.obj::
     cl $(CCOPTS) -c $<


### PR DESCRIPTION
This will catch the MSVC codegen bug that breaks AES key expansion, if the fix ever regresses.