### PR TITLE
Switch to HACL* for AES-128, to avoid crashes on non-AESNI CPUs

### DIFF
--- a/src/tls/Makefile.Kremlin
+++ b/src/tls/Makefile.Kremlin
@@ -78,7 +78,7 @@ endif
 # Sanity checks and shared directories definitions
 
 CURVE_DIR	= $(HACL_HOME)/code/curve25519/x25519-c
-SECURE_OUT	= $(HACL_HOME)/secure_api/out/vale_aes_abstract_id/crypto
+SECURE_OUT	= $(HACL_HOME)/secure_api/out/hacl_aes_abstract_id/crypto
 VALE_DIR	= $(HACL_HOME)/secure_api/vale/asm
 UINT128_DIR	= $(HACL_HOME)/secure_api/out/runtime_switch/uint128
 

--- a/src/tls/extract/cstubs/RegionAllocator.c
+++ b/src/tls/extract/cstubs/RegionAllocator.c
@@ -413,7 +413,7 @@ int HeapRegionInitialize()
 void HeapRegionCleanup(void)
 {
     // The mapping list should be empty
-    NT_ASSERT(IsListEmpty(&g_mapping_list.entries));
+    NT_ASSERT(IsListEmpty(&g_mapping_list));
     HeapRegionDestroy(&g_global_region);
 }
 

--- a/src/tls/extract/cstubs/buffer_bytes.c
+++ b/src/tls/extract/cstubs/buffer_bytes.c
@@ -15,7 +15,10 @@ FStar_Bytes_bytes BufferBytes_to_bytes(Prims_nat l, uint8_t *buf) {
 
 void BufferBytes_store_bytes(Prims_nat len, uint8_t *buf, Prims_nat i,
                              FStar_Bytes_bytes b) {
-  assert(i <= len);
+  if (i > len) {
+      KRML_HOST_PRINTF("BufferBytes_store_bytes i must be <= len (i=%d len=%d)\n", i, len);
+      KRML_HOST_EXIT(252);
+  }
   if (b.length > 0 && i < len)
     memcpy(buf + i, b.data + i, len - i);
 }

--- a/src/tls/extract/cstubs/mitlsffi.c
+++ b/src/tls/extract/cstubs/mitlsffi.c
@@ -386,6 +386,9 @@ static TLSConstants_nego_action nego_cb_proxy(FStar_Dyn_dyn cbs, TLSConstants_pr
       if(app_cookie != NULL) memcpy(c, app_cookie, app_cookie_len);
       a.val.case_Nego_retry = (FStar_Bytes_bytes){.data = (const char*)c, .length = app_cookie_len};
       break;
+    default:
+      KRML_HOST_PRINTF("mitls_nego_action: unsupported (%04x)\n", r);
+      KRML_HOST_EXIT(1);
   }
 
   return a;


### PR DESCRIPTION
Also fix compilation errors when building debug for Windows AMD64.

Thanks to @msprotz for the Makefile.Kremlin change.