### PR TITLE
Remove assert() calls

### DIFF
--- a/src/tls/extract/cstubs/RegionAllocator.c
+++ b/src/tls/extract/cstubs/RegionAllocator.c
@@ -1,5 +1,4 @@
 #include <memory.h>
-#include <assert.h>
 #include <stdio.h>
 #if __APPLE__
 #include <sys/errno.h> // OS/X only provides include/sys/errno.h

--- a/src/tls/extract/cstubs/buffer_bytes.c
+++ b/src/tls/extract/cstubs/buffer_bytes.c
@@ -1,8 +1,6 @@
 #include "FStar.h"
 #include "krembytes.h"
 
-#include <assert.h>
-
 FStar_Bytes_bytes BufferBytes_to_bytes(Prims_nat l, uint8_t *buf) {
   if (buf == NULL || l == 0)
     return FStar_Bytes_empty_bytes;

--- a/src/tls/extract/cstubs/mitlsffi.c
+++ b/src/tls/extract/cstubs/mitlsffi.c
@@ -1,5 +1,4 @@
 #include <memory.h>
-#include <assert.h>
 #include <stdarg.h>
 #if __APPLE__
 #include <sys/errno.h> // OS/X only provides include/sys/errno.h
@@ -796,7 +795,10 @@ static int get_exporter(Connection_connection cxn, int early, /* out */ mitls_se
   secret->hash = ret.v.fst;
   secret->ae = ret.v.snd;
   size_t len=ret.v.thd.length;
-  assert(len <= sizeof(secret->secret));
+  if (len > sizeof(secret->secret)) {
+    KRML_HOST_PRINTF("Unexpected secret length");
+    KRML_HOST_EXIT(1);
+  }
   memcpy(secret->secret, ret.v.thd.data, len);
   return 1;
 }


### PR DESCRIPTION
They aren't supported on Windows kernelmode.  Not caught until now as we have been building retail builds, not checked/debug.