### PR TITLE
Consumption of parser32 (requested by @barrybo)

### DIFF
--- a/src/lowparse/LowParse.SLow.Base.fst
+++ b/src/lowparse/LowParse.SLow.Base.fst
@@ -31,6 +31,28 @@ let parser32
 : Tot Type0
 = (input: bytes32) -> Tot (res: option (t * U32.t) { parser32_correct p input res } )
 
+let parser32_consumes
+  (#k: parser_kind)
+  (#t: Type0)
+  (#p: parser k t)
+  (p32: parser32 p)
+  (input: bytes32)
+: Lemma
+  (Some? (p32 input) ==> (let (Some (_, consumed)) = p32 input in U32.v consumed <= B32.length input))
+= ()
+
+let parser32_consumes'
+  (#k: parser_kind)
+  (#t: Type0)
+  (#p: parser k t)
+  (p32: parser32 p)
+  (input: bytes32)
+: Lemma
+  (match p32 input with
+  | Some (_, consumed) -> U32.v consumed <= B32.length input
+  | _ -> True)
+= ()
+
 inline_for_extraction
 let make_parser32
   (#k: parser_kind)

--- a/src/lowparse/LowParseExample.fst
+++ b/src/lowparse/LowParseExample.fst
@@ -1,7 +1,19 @@
 module LowParseExample
 
-let f (input: FStar.Bytes.bytes) : Tot (option (LowParseExample.Aux.t * FStar.UInt32.t)) =
-  LowParseExample.Aux.parse32_t input
+#reset-options "--using_facts_from '* -LowParse +LowParse.Spec.Base +LowParse.SLow.Base'"
+
+let f (input: FStar.Bytes.bytes) : Pure (option (LowParseExample.Aux.t * FStar.UInt32.t))
+  (requires True)
+  (ensures (fun res ->
+    match res with
+    | None -> True
+    | Some (_, consumed) -> FStar.UInt32.v consumed <= FStar.Bytes.length input
+  ))
+= [@inline_let]
+  let res = LowParseExample.Aux.parse32_t input in
+  [@inline_let]
+  let _ = LowParse.SLow.Base.parser32_consumes LowParseExample.Aux.parse32_t input in
+  res
 
 let g (input: FStar.Bytes.bytes) : Tot (option (LowParse.SLow.array LowParseExample.Aux.t 18 * FStar.UInt32.t)) =
   LowParseExample.Aux.parse32_t_array input


### PR DESCRIPTION
A parser32 consumes at most the length of the input.
