### PR TITLE
Heap Regions

### DIFF
--- a/src/tls/extract/Kremlin-Library/Makefile
+++ b/src/tls/extract/Kremlin-Library/Makefile
@@ -27,6 +27,9 @@ else ifeq ($(UNAME),Linux)
   export LD_LIBRARY_PATH
 endif
 
+# Force-include RegionAllocator.h and enable heap regions in all builds
+CFLAGS := $(CFLAGS) -include RegionAllocator.h -DUSE_HEAP_REGIONS
+
 ifneq (,$(EVEREST_WINDOWS))
 CFLAGS+=-DKRML_NOUINT128 -DKRML_SEPARATE_UINT128 # -DKRML_NOSTRUCT_PASSING
 endif

--- a/src/tls/extract/cstubs/RegionAllocator.c
+++ b/src/tls/extract/cstubs/RegionAllocator.c
@@ -680,5 +680,4 @@ void HeapRegionFree(void* pv)
 {
     free(pv);
 }
-
 #endif

--- a/src/tls/extract/cstubs/RegionAllocator.c
+++ b/src/tls/extract/cstubs/RegionAllocator.c
@@ -173,7 +173,7 @@ void* HeapRegionMalloc(size_t cb)
     void *pv = HeapAlloc(heap->heap, 0, cb);
     UpdateStatisticsAfterMalloc(&heap->stats, pv, cb);
     if (pv == NULL) {
-        RaiseException(MITLS_OUT_OF_MEMORY_EXCEPTION, EXCEPTION_NONCONTINUABLE, 0, NULL);
+        RaiseException((DWORD)MITLS_OUT_OF_MEMORY_EXCEPTION, EXCEPTION_NONCONTINUABLE, 0, NULL);
     }
     
     return pv;

--- a/src/tls/extract/cstubs/RegionAllocator.c
+++ b/src/tls/extract/cstubs/RegionAllocator.c
@@ -283,13 +283,13 @@ int HeapRegionInitialize()
 // Global termination
 void HeapRegionCleanup(void)
 {
-    HeapRegionDestroy(g_global_region);
+    HeapRegionDestroy((HEAP_REGION)&g_global_region);
     pthread_key_delete(g_region_heap_slot);
     pthread_mutex_destroy(&g_global_region_lock);
 }
 
 // Create a new region and make it this thread's default
-void HeapRegionCreateAndRegister(HEAP_REGION *prgn, jmp_buf *penv)
+HEAP_REGION HeapRegionCreateAndRegister(HEAP_REGION *prgn, jmp_buf *penv)
 {
     HEAP_REGION oldrgn = (HEAP_REGION)pthread_getspecific(g_region_heap_slot);
     region *p = malloc(sizeof(region));
@@ -335,10 +335,11 @@ HEAP_REGION HeapRegionEnter(HEAP_REGION rgn, jmp_buf *penv)
 {
     HEAP_REGION oldrgn = (HEAP_REGION)pthread_getspecific(g_region_heap_slot);
     pthread_setspecific(g_region_heap_slot, rgn);
-    if (rgn == NULL) {
+    region *heap = (region*)rgn;
+    if (heap == NULL) {
         g_global_region.penv = penv;
     } else {
-        rgn->penv = penv;
+        heap->penv = penv;
     }
     return oldrgn;
 }

--- a/src/tls/extract/cstubs/RegionAllocator.c
+++ b/src/tls/extract/cstubs/RegionAllocator.c
@@ -7,18 +7,21 @@
 #include <malloc.h>
 #include <errno.h> // MinGW only provides include/errno.h
 #endif
-#if defined(_MSC_VER) || defined(__MINGW32__)
-#define IS_WINDOWS 1
+#if defined(_MSC_VER)
+  #define IS_WINDOWS 1
   #ifdef _KERNEL_MODE
     #include <nt.h>
     #include <ntrtl.h>
   #else
     #include <windows.h>
   #endif
-#else
-#define IS_WINDOWS 0
-#include <pthread.h>
-#include <sys/queue.h>
+#elif defined(__MINGW32__)
+  #define IS_WINDOWS 1
+  #include <windows.h>
+#else // Linux or gcc/cygwin
+  #define IS_WINDOWS 0
+  #include <pthread.h>
+  #include <sys/queue.h>
 #endif
 
 #include "RegionAllocator.h"
@@ -80,6 +83,9 @@ void UpdateStatisticsAfterFree(region_statistics *stats, size_t cb)
 #if IS_WINDOWS
 typedef struct _region {
     HANDLE heap;
+#if !defined(_MSC_VER)
+    jmp_buf *penv;
+#endif
 #if REGION_STATISTICS
     region_statistics stats;
 #endif
@@ -116,7 +122,11 @@ void HeapRegionCleanup(void)
 }
 
 // Create a new heap region
-HEAP_REGION HeapRegionCreateAndRegister(HEAP_REGION *prgn)
+HEAP_REGION HeapRegionCreateAndRegister(HEAP_REGION *prgn
+#if !defined(_MSC_VER)
+  , jmp_buf *penv
+#endif
+)
 {
     // Allocate a heap with:
     // - no internal locking
@@ -127,7 +137,11 @@ HEAP_REGION HeapRegionCreateAndRegister(HEAP_REGION *prgn)
     memset(heap, 0, sizeof(*heap));
     heap->heap = h;
     // Make it the heap for this callgraph
-    HEAP_REGION oldrgn = HeapRegionEnter(heap);
+    HEAP_REGION oldrgn = HeapRegionEnter(heap
+#if !defined(_MSC_VER)
+        ,penv
+#endif
+    );
     
     *prgn = heap;
     return oldrgn;
@@ -151,10 +165,22 @@ void PrintHeapRegionStatistics(HEAP_REGION rgn)
     PrintRegionStatistics(heap, &heap->stats);
 }
 
-HEAP_REGION HeapRegionEnter(HEAP_REGION rgn)
+HEAP_REGION HeapRegionEnter(HEAP_REGION rgn
+#if !defined(_MSC_VER)
+  , jmp_buf *penv
+#endif
+)
 {
     HEAP_REGION oldrgn = TlsGetValue(g_region_heap_slot);
     TlsSetValue(g_region_heap_slot, rgn);
+#if !defined(_MSC_VER)
+    region *heap = (region*)rgn;
+    if (heap == NULL) {
+        g_global_region.penv = penv;
+    } else {
+        heap->penv = penv;
+    }
+#endif
     return oldrgn;
 }
 
@@ -173,7 +199,11 @@ void* HeapRegionMalloc(size_t cb)
     void *pv = HeapAlloc(heap->heap, 0, cb);
     UpdateStatisticsAfterMalloc(&heap->stats, pv, cb);
     if (pv == NULL) {
+#if defined(_MSC_VER)
         RaiseException((DWORD)MITLS_OUT_OF_MEMORY_EXCEPTION, EXCEPTION_NONCONTINUABLE, 0, NULL);
+#else
+        longjmp(*heap->penv, 1);
+#endif
     }
     
     return pv;
@@ -259,13 +289,14 @@ void HeapRegionCleanup(void)
 }
 
 // Create a new region and make it this thread's default
-void HeapRegionCreateAndRegister(HEAP_REGION *prgn)
+void HeapRegionCreateAndRegister(HEAP_REGION *prgn, jmp_buf *penv)
 {
     HEAP_REGION oldrgn = (HEAP_REGION)pthread_getspecific(g_region_heap_slot);
     region *p = malloc(sizeof(region));
     if (p) {
         memset(p, 0, sizeof(region));
         LIST_INIT(&p->entries);
+        p->penv = penv;
         pthread_setspecific(g_region_heap_slot, p);
     }
     *prgn = (HEAP_REGION)p;
@@ -383,7 +414,7 @@ void HeapRegionFree(void* pv)
     free(e);
 }
 
-#endif // !IS_WINDOWS
+#endif // !defined(_MSC_VER)
     
 
 // End of USE_PROCESS_HEAP

--- a/src/tls/extract/cstubs/RegionAllocator.c
+++ b/src/tls/extract/cstubs/RegionAllocator.c
@@ -513,6 +513,7 @@ LIST_ENTRY *HeapRegionFind(void)
             ExReleaseFastMutex(&g_mapping_lock);
             return r->region;
         }
+        p = p->Flink;
     }
     ExReleaseFastMutex(&g_mapping_lock);    
     return NULL;

--- a/src/tls/extract/cstubs/RegionAllocator.h
+++ b/src/tls/extract/cstubs/RegionAllocator.h
@@ -17,11 +17,7 @@ This file has multiple compilation options:
 
 ******/
 
-#if defined(_MSC_VER) || defined(__MINGW32__)
-#define IS_WINDOWS 1
-#else
-#define IS_WINDOWS 0
-#endif
+#include <stdlib.h> // for size_t
 
 typedef void *HEAP_REGION;
 
@@ -45,7 +41,7 @@ void HeapRegionFree(void* pv);
 // be freed when the region is destroyed.  A default region holds allocations
 // made outside of ENTER/LEAVE.  It will be freed when the region allocator
 // is cleaned up.
-#if IS_WINDOWS
+#if defined(_MSC_VER)
   #define FACILITY_EVEREST 255
   #define CODE_OUT_OF_MEMORY 5
   #define MITLS_OUT_OF_MEMORY_EXCEPTION MAKE_HRESULT(1,FACILITY_EVEREST,CODE_OUT_OF_MEMORY)
@@ -74,7 +70,8 @@ void HeapRegionFree(void* pv);
   #define DESTROY_HEAP_REGION(rgn) HeapRegionDestroy(rgn)
   #define HAD_OUT_OF_MEMORY         (HadHeapException != 0)
   HEAP_REGION HeapRegionEnter(HEAP_REGION rgn);
-#else
+  HEAP_REGION HeapRegionCreateAndRegister(HEAP_REGION *prgn);
+#else // !defined(_MSC_VER), so mingw, gcc, etc.
   #include <setjmp.h>
 
   #define ENTER_GLOBAL_HEAP_REGION() ENTER_HEAP_REGION(NULL)
@@ -87,15 +84,27 @@ void HeapRegionFree(void* pv);
     if (setjmp(jmp_buf_out_of_memory)) { \
       HadHeapException = 1; \
     } else {
-  #define LEAVE_HEAP_REGION()    } HeapRegionLeave(OldRegion)
-  #define CREATE_HEAP_REGION(prgn)   HeapRegionCreateAndRegister(prgn); {
+
+  #define LEAVE_HEAP_REGION() \
+    } \
+    HeapRegionLeave(OldRegion)
+
+  #define CREATE_HEAP_REGION(prgn) \
+    jmp_buf jmp_buf_out_of_memory; \
+    char HadHeapException = 0; \
+    HEAP_REGION OldRegion = HeapRegionCreateAndRegister(prgn, &jmp_buf_out_of_memory); \
+    if (setjmp(jmp_buf_out_of_memory)) { \
+      HadHeapException = 1; \
+    } else {
+
   #define VALID_HEAP_REGION(rgn)    ((rgn) != NULL)
   #define DESTROY_HEAP_REGION(rgn) HeapRegionDestroy(rgn)
   #define HAD_OUT_OF_MEMORY         (HadHeapException != 0)
   HEAP_REGION HeapRegionEnter(HEAP_REGION rgn, jmp_buf* penv);
-#endif
+  HEAP_REGION HeapRegionCreateAndRegister(HEAP_REGION *prgn, jmp_buf* penv);
+#endif // !defined(_MSC_VER), so mingw, gcc, etc.
+
 void HeapRegionLeave(HEAP_REGION oldrgn);
-HEAP_REGION HeapRegionCreateAndRegister(HEAP_REGION *prgn);
 void HeapRegionDestroy(HEAP_REGION rgn);
 
 #elif USE_KERNEL_REGIONS
@@ -103,7 +112,7 @@ void HeapRegionDestroy(HEAP_REGION rgn);
 // the region will be freed when the region is destroyed.  A default region
 // holds allocations made outside of ENTER/LEAVE.  It will be freed when
 // the region allocator is cleaned up.
-#if IS_WINDOWS
+#if defined(_MSC_VER)
   #define MITLS_OUT_OF_MEMORY_EXCEPTION 0x80ff0005
   
   typedef struct {
@@ -149,11 +158,15 @@ void HeapRegionDestroy(HEAP_REGION rgn);
   void HeapRegionRegister(region_entry* pe, HEAP_REGION rgn);
   void HeapRegionUnregister(region_entry* pe);
   void HeapRegionDestroy(HEAP_REGION rgn);
-#else
-  #error Non-Windows support is NYY
-#endif
+#else // !defined(_MSC_VER)
+  #error Non-Windows support is NYI
+#endif //!defined(_MSC_VER)
 
-#else
+#define KRML_HOST_MALLOC HeapRegionMalloc
+#define KRML_HOST_CALLOC HeapRegionCalloc
+#define KRML_HOST_FREE   HeapRegionFree
+
+#else // !USE_HEAP_REGIONS && !USE_KERNEL_REGIONS
 // Use the single process-wide heap.  All unfreed allocations will be leaked.
 
 #ifndef TRUE
@@ -170,6 +183,6 @@ void HeapRegionDestroy(HEAP_REGION rgn);
 #define DESTROY_HEAP_REGION(rgn)
 #define HAD_OUT_OF_MEMORY 0
 
-#endif
+#endif // !USE_HEAP_REGIONS && !USE_KERNEL_REGIONS
 
 #endif // HEADER_REGIONALLOCATOR_H

--- a/src/tls/extract/cstubs/mitlsffi.c
+++ b/src/tls/extract/cstubs/mitlsffi.c
@@ -959,8 +959,8 @@ int MITLS_CALLCONV FFI_mitls_quic_create(/* out */ quic_state **state, quic_conf
         UNLOCK_MUTEX(&lock);
         if (!b) {
             KRML_HOST_FREE(st);
-            DESTROY_HEAP_REGION(rgn);
-            return 0; // failure
+            st = NULL;
+            goto Exit;
         }
     }
 
@@ -1032,6 +1032,7 @@ int MITLS_CALLCONV FFI_mitls_quic_create(/* out */ quic_state **state, quic_conf
     }
 #endif
 
+Exit:;
     LEAVE_HEAP_REGION();
     if (HAD_OUT_OF_MEMORY || st == NULL) {
       DESTROY_HEAP_REGION(rgn);

--- a/src/windows/CommonInclude.h
+++ b/src/windows/CommonInclude.h
@@ -25,9 +25,6 @@ __declspec(noreturn) extern void KremlExit(int n);
 
 #define USE_HEAP_REGIONS 1
 #include "RegionAllocator.h"
-#define KRML_HOST_MALLOC HeapRegionMalloc
-#define KRML_HOST_CALLOC HeapRegionCalloc
-#define KRML_HOST_FREE   HeapRegionFree
 
 #define KRML_HOST_PRINTF DbgPrint
 #define KRML_HOST_EPRINTF DbgPrint


### PR DESCRIPTION
- Fix a bug reported against QUIC, where a call to FFI_mitls_find_custom_extension() inside a miTLS-to-host callback leaves the rest of the stack using the global heap instead of the per-connection heap.  The fix is to stack enters and leaves of heap regions.  This only affects the usermode allocator... the kernelmode was already stacked.

- Enable the region allocator on all versions of libmitls.so.  I built and tested on Linux/gcc, cygwin/mingw, and Windows/MSVC.  OS/X might need tweaking.  The mingw build uses Win32 thread-local-storage and heap APIs, but setjmp/longjmp... it makes the code less-than-pretty, but efficient.

- Enable out-of-memory handling at the FFI on all platforms.

- Fix a warning in the MSVC build... casting an HRESULT to a DWORD in RaiseException() in RegionAllocator.c.  I don't know why our MSVC build didn't catch this.