### PR TITLE
LowParse: use new modifies patterns

### DIFF
--- a/src/lowparse/LowParse.BigEndianImpl.Low.fst
+++ b/src/lowparse/LowParse.BigEndianImpl.Low.fst
@@ -10,7 +10,7 @@ module M = LowParse.Math
 module G = FStar.Ghost
 
 module B = LowStar.Buffer
-module MO = LowStar.Modifies
+module MO = LowStar.ModifiesPat
 module HS = FStar.HyperStack
 module HST = FStar.HyperStack.ST
 

--- a/src/lowparse/LowParse.Low.Base.fst
+++ b/src/lowparse/LowParse.Low.Base.fst
@@ -2,7 +2,7 @@ module LowParse.Low.Base
 include LowParse.Spec.Base
 
 module B = LowStar.Buffer
-module M = LowStar.Modifies
+module M = LowStar.ModifiesPat
 module U32 = FStar.UInt32
 module HS = FStar.HyperStack
 module HST = FStar.HyperStack.ST


### PR DESCRIPTION
Patterns on modifies clauses were moved into a specific module, LowParse.ModifiesPat, which includes LowParse.Modifies.
